### PR TITLE
Fix HA integration COP calculation

### DIFF
--- a/Integrations/Home Assistant/heishamon.yaml
+++ b/Integrations/Home Assistant/heishamon.yaml
@@ -563,19 +563,19 @@ sensor:
         friendly_name: "Heishamon Energy Production"
         unit_of_measurement: 'W'
         value_template: >-
-          {%- if states('sensor.heishamon_dhw_power_produced') != "0" -%}
-            {{ states('sensor.heishamon_dhw_power_produced') }}
+          {%- if states('sensor.heishamon_aquarea_hw_power_produced') != "0" -%}
+            {{ states('sensor.heishamon_aquarea_dhw_power_produced') }}
           {%- else -%}
-            {{ states('sensor.heishamon_power_produced') }}
+            {{ states('sensor.heishamon_aquarea_power_produced') }}
           {%- endif -%}
       heishamon_w_consumption:
         friendly_name: "Heishamon Energy Consumption"
         unit_of_measurement: 'W'
         value_template: >-
-          {%- if states('sensor.heishamon_dhw_power_consumed') != "0" -%}
-            {{ states('sensor.heishamon_dhw_power_consumed') }}
+          {%- if states('sensor.heishamon_aquarea_dhw_power_consumed') != "0" -%}
+            {{ states('sensor.heishamon_aquarea_dhw_power_consumed') }}
           {%- else -%}
-            {{ states('sensor.heishamon_power_consumed') }}
+            {{ states('sensor.heishamon_aquarea_power_consumed') }}
           {%- endif -%}
 
 

--- a/Integrations/Home Assistant/heishamon.yaml
+++ b/Integrations/Home Assistant/heishamon.yaml
@@ -223,7 +223,7 @@ input_select:
 sensor:
   #TOP0 - Power state
   - platform: mqtt
-    name: Heishamon Aquarea Power State
+    name: Aquarea Power State
     state_topic: "panasonic_heat_pump/sdc/Heatpump_State"
     value_template: >-
       {%- if value == "0" -%}
@@ -234,13 +234,13 @@ sensor:
 
   #TOP1 - Pumpflow
   - platform: mqtt
-    name: Heishamon Aquarea Pump Flow
+    name: Aquarea Pump Flow
     state_topic: "panasonic_heat_pump/sdc/Pump_Flow"
     unit_of_measurement: 'L/min'
 
-  #TOP2 - Force DHW State
+  #TOP2 - Force DHW
   - platform: mqtt
-    name: Heishamon Aquarea Force DHW Mode
+    name: Aquarea Force DHW Mode
     state_topic: "panasonic_heat_pump/sdc/Force_DHW_State"
     value_template: >-
       {%- if value == "0" -%}
@@ -251,7 +251,7 @@ sensor:
 
   #TOP4 - Heat mode (Hot water, Heat or Hot water + heat)
   - platform: mqtt
-    name: Heishamon Aquarea Mode
+    name: Aquarea Mode
     state_topic: "panasonic_heat_pump/sdc/Operating_Mode_State"
     value_template: >-
       {%- if value == "0" -%}
@@ -272,72 +272,72 @@ sensor:
       
   #TOP5 - Water inlet temp
   - platform: mqtt
-    name: Heishamon Aquarea Inlet Temperature
+    name: Aquarea Inlet Temperature
     state_topic: "panasonic_heat_pump/sdc/Main_Inlet_Temp"
     unit_of_measurement: '°C'
 
   #TOP6 - Water outlet temp
   - platform: mqtt
-    name: Heishamon Aquarea Outlet Temperature
+    name: Aquarea Outlet Temperature
     state_topic: "panasonic_heat_pump/sdc/Main_Outlet_Temp"
     unit_of_measurement: '°C'
 
   #TOP7 - Water outlet target temp
   - platform: mqtt
-    name: Heishamon Aquarea Outlet Target Temperature
+    name: Aquarea Outlet Target Temperature
     state_topic: "panasonic_heat_pump/sdc/Main_Target_Temp"
     unit_of_measurement: '°C'
 
   #TOP8 - Compressor frequency
   - platform: mqtt
-    name: Heishamon Aquarea Compressor Frequency
+    name: Aquarea Compressor Frequency
     state_topic: "panasonic_heat_pump/sdc/Compressor_Freq"
     unit_of_measurement: 'Hz'
 
   #TOP9 - Tank set temperature
   - platform: mqtt
-    name: Heishamon Aquarea Tank Set Temperature
+    name: Aquarea Tank Set Temperature
     state_topic: "panasonic_heat_pump/sdc/DHW_Target_Temp"
     unit_of_measurement: '°C'
 
   #TOP10 - Tank current temperature
   - platform: mqtt
-    name: Heishamon Aquarea Actual Tank Temperature
+    name: Aquarea Actual Tank Temperature
     state_topic: "panasonic_heat_pump/sdc/DHW_Temp"
     unit_of_measurement: '°C'
 
   #TOP11 - Compressor Operating Time
   - platform: mqtt
-    name: Heishamon Aquarea Compressor Operating Hours
+    name: Aquarea Compressor Operating Hours
     state_topic: "panasonic_heat_pump/sdc/Operations_Hours"
     unit_of_measurement: 'Hours'
 
   #TOP12 - Compressor On/Off cycle number
   - platform: mqtt
-    name: Heishamon Aquarea Compressor Start/Stop Counter
+    name: Aquarea Compressor Start/Stop Counter
     state_topic: "panasonic_heat_pump/sdc/Operations_Counter"
 
   #TOP14 - Outdoor unit ambient temperature
   - platform: mqtt
-    name: Heishamon Aquarea Outdoor Ambient
+    name: Aquarea Outdoor Ambient
     state_topic: "panasonic_heat_pump/sdc/Outside_Temp"
     unit_of_measurement: '°C'
 
   #TOP15 - Heating power produced
   - platform: mqtt
-    name: Heishamon Aquarea Power Produced
+    name: Aquarea Power Produced
     state_topic: "panasonic_heat_pump/sdc/Heat_Energy_Production"
     unit_of_measurement: 'W'
 
   #TOP16 - Heating power consumed
   - platform: mqtt
-    name: Heishamon Aquarea Power Consumed
+    name: Aquarea Power Consumed
     state_topic: "panasonic_heat_pump/sdc/Heat_Energy_Consumption"
     unit_of_measurement: 'W'
 
-  #TOP17 - Heating powerfull mode
+  #TOP17 - Heating powerful mode
   - platform: mqtt
-    name: Heishamon Aquarea Powerful Mode
+    name: Aquarea Powerful Mode
     state_topic: "panasonic_heat_pump/sdc/Powerful_Mode_Time"
     unit_of_measurement: 'Min'
     value_template: >-
@@ -345,18 +345,20 @@ sensor:
 
   #TOP18 - Heating quiet mode
   - platform: mqtt
-    name: Heishamon Aquarea Quiet Mode
+    name: Aquarea Quiet Mode
     state_topic: "panasonic_heat_pump/sdc/Quiet_Mode_Level"
     value_template: >-
       {%- if value == "4" -%}
         Scheduled
+      {%- elif value == "0" -%}
+        Off
       {%- else -%}
         {{ value }}
       {%- endif -%}
 
   #TOP19 - Holiday Mode
   - platform: mqtt
-    name: Heishamon Aquarea Holiday Mode
+    name: Aquarea Holiday Mode
     state_topic: "panasonic_heat_pump/sdc/Holiday_Mode_State"
     value_template: >-
       {%- if value == "0" -%}
@@ -367,7 +369,7 @@ sensor:
 
   #TOP20 - 3-way valve state
   - platform: mqtt
-    name: Heishamon Aquarea 3-way Valve
+    name: Aquarea 3-way Valve
     state_topic: "panasonic_heat_pump/sdc/ThreeWay_Valve_State"
     value_template: >-
       {%- if value == "0" -%}
@@ -378,13 +380,13 @@ sensor:
 
   #TOP21 - Outside pipe temp
   - platform: mqtt
-    name: Heishamon Aquarea Outdoor Pipe Temperature
+    name: Aquarea Outdoor Pipe Temperature
     state_topic: "panasonic_heat_pump/sdc/Outside_Pipe_Temp"
     unit_of_measurement: '°C'
 
   #TOP26 - Defrost state
   - platform: mqtt
-    name: Heishamon Aquarea Defrost State
+    name: Aquarea Defrost State
     state_topic: "panasonic_heat_pump/sdc/Defrosting_State"
     value_template: >-
       {%- if value == "0" -%}
@@ -395,72 +397,72 @@ sensor:
 
   #TOP27 - Heatshift Temperature
   - platform: mqtt
-    name: Heishamon Aquarea Heatshift Temperature
+    name: Aquarea Heatshift Temperature
     state_topic: "panasonic_heat_pump/sdc/Z1_Heat_Request_Temp"
     unit_of_measurement: '°C'
 
   #TOP40 - DHW power produced
   - platform: mqtt
-    name: Heishamon Aquarea DHW Power Produced
+    name: Aquarea DHW Power Produced
     state_topic: "panasonic_heat_pump/sdc/DHW_Energy_Production"
     unit_of_measurement: 'W'
 
   #TOP41 - DHW power consumed
   - platform: mqtt
-    name: Heishamon Aquarea DHW Power Consumed
+    name: Aquarea DHW Power Consumed
     state_topic: "panasonic_heat_pump/sdc/DHW_Energy_Consumption"
     unit_of_measurement: 'W'
 
   #TOP44 - Last active error
   - platform: mqtt
-    name: Heishamon Aquarea Last Error
+    name: Aquarea Last Error
     state_topic: "panasonic_heat_pump/sdc/Error"
 
-  #TOP49 - Water HEX Outlet temp
+  #TOP49 - Main HEX Outlet temp
   - platform: mqtt
-    name: Heishamon Aquarea Main HEX Outlet Temperature
+    name: Aquarea Main HEX Outlet Temperature
     state_topic: "panasonic_heat_pump/sdc/Main_Hex_Outlet_Temp"
     unit_of_measurement: '°C'
 
   #TOP50 - Discharge temp
   - platform: mqtt
-    name: Heishamon Aquarea Discharge Temperature
+    name: Aquarea Discharge Temperature
     state_topic: "panasonic_heat_pump/sdc/Discharge_Temp"
     unit_of_measurement: '°C'
 
   #TOP51 - Inside Pipe temp
   - platform: mqtt
-    name: Heishamon Aquarea Inside Pipe Temperature
+    name: Aquarea Inside Pipe Temperature
     state_topic: "panasonic_heat_pump/sdc/Inside_Pipe_Temp"
     unit_of_measurement: '°C'
 
   #TOP52 - Defrost temp
   - platform: mqtt
-    name: Heishamon Aquarea Defrost Temperature
+    name: Aquarea Defrost Temperature
     state_topic: "panasonic_heat_pump/sdc/Defrost_Temp"
     unit_of_measurement: '°C'
 
   #TOP53 - Eva Outlet temp
   - platform: mqtt
-    name: Heishamon Aquarea Eva Outlet Temperature
+    name: Aquarea Eva Outlet Temperature
     state_topic: "panasonic_heat_pump/sdc/Eva_Outlet_Temp"
     unit_of_measurement: '°C'
 
   #TOP54 - Bypass Outlet temp
   - platform: mqtt
-    name: Heishamon Aquarea Bypass Outlet Temperature
+    name: Aquarea Bypass Outlet Temperature
     state_topic: "panasonic_heat_pump/sdc/Bypass_Outlet_Temp"
     unit_of_measurement: '°C'
 
   #TOP55 - lpm temp
   - platform: mqtt
-    name: Heishamon Aquarea Ipm Temperature
+    name: Aquarea Ipm Temperature
     state_topic: "panasonic_heat_pump/sdc/Ipm_Temp"
     unit_of_measurement: '°C'
 
   #TOP58 - Tank electric heater allowed state
   - platform: mqtt
-    name: Heishamon Aquarea Tank Heater Enabled
+    name: Aquarea Tank Heater Enabled
     state_topic: "panasonic_heat_pump/sdc/DHW_Heater_State"
     value_template: >-
       {%- if value == "0" -%}
@@ -471,7 +473,7 @@ sensor:
 
   #TOP59 - Water electric heater allowed state
   - platform: mqtt
-    name: Heishamon Aquarea Room Heater Enabled
+    name: Aquarea Room Heater Enabled
     state_topic: "panasonic_heat_pump/sdc/Room_Heater_State"
     value_template: >-
       {%- if value == "0" -%}
@@ -482,7 +484,7 @@ sensor:
 
   #TOP60 - Internal heater state
   - platform: mqtt
-    name: Heishamon Aquarea Internal Heater State
+    name: Aquarea Internal Heater State
     state_topic: "panasonic_heat_pump/sdc/Internal_Heater_State"
     value_template: >-
       {%- if value == "0" -%}
@@ -493,7 +495,7 @@ sensor:
 
   #TOP61 - External heater state
   - platform: mqtt
-    name: Heishamon Aquarea External Heater State
+    name: Aquarea External Heater State
     state_topic: "panasonic_heat_pump/sdc/External_Heater_State"
     value_template: >-
       {%- if value == "0" -%}
@@ -502,39 +504,40 @@ sensor:
         On
       {%- endif -%}
 
+
   #TOP62 - Fan1 speed
   - platform: mqtt
-    name: Heishamon Aquarea Fan 1 Speed
+    name: Aquarea Fan 1 Speed
     state_topic: "panasonic_heat_pump/sdc/Fan1_Motor_Speed"
     unit_of_measurement: "R/min"
 
   #TOP63 - Fan2 speed
   - platform: mqtt
-    name: Heishamon Aquarea Fan 2 Speed
+    name: Aquarea Fan 2 Speed
     state_topic: "panasonic_heat_pump/sdc/Fan2_Motor_Speed"
     unit_of_measurement: "R/min"
 
   #TOP64 - High pressure
   - platform: mqtt
-    name: Heishamon Aquarea High pressure
+    name: Aquarea High pressure
     state_topic: "panasonic_heat_pump/sdc/High_Pressure"
     unit_of_measurement: "Kgf/cm2"
 
   #TOP65 - Pump speed
   - platform: mqtt
-    name: Heishamon Aquarea Pump Speed
+    name: Aquarea Pump Speed
     state_topic: "panasonic_heat_pump/sdc/Pump_Speed"
     unit_of_measurement: "R/min"
 
   #TOP66 - Low pressure
   - platform: mqtt
-    name: Heishamon Aquarea Low pressure
+    name: Aquarea Low pressure
     state_topic: "panasonic_heat_pump/sdc/Low_Pressure"
     unit_of_measurement: "Kgf/cm2"
 
   #TOP66 - Compressor Current
   - platform: mqtt
-    name: Heishamon Aquarea Compressor Current
+    name: Aquarea Compressor Current
     state_topic: "panasonic_heat_pump/sdc/Compressor_Current"
     unit_of_measurement: "A"
 
@@ -543,7 +546,7 @@ sensor:
   - platform: template
     sensors:
       heishamon_cop:
-        friendly_name: "Heishamon Aquarea COP"
+        friendly_name: "Aquarea COP"
         unit_of_measurement: "x"
         value_template: >-
           {%- if states('sensor.heishamon_w_production') != "Unknown" -%}
@@ -560,22 +563,22 @@ sensor:
   - platform: template
     sensors:
       heishamon_w_production:
-        friendly_name: "Heishamon Energy Production"
+        friendly_name: "Aquarea Energy Production"
         unit_of_measurement: 'W'
         value_template: >-
-          {%- if states('sensor.heishamon_aquarea_hw_power_produced') != "0" -%}
-            {{ states('sensor.heishamon_aquarea_dhw_power_produced') }}
+          {%- if states('sensor.aquarea_dhw_power_produced') != "0" -%}
+            {{ states('sensor.aquarea_dhw_power_produced') }}
           {%- else -%}
-            {{ states('sensor.heishamon_aquarea_power_produced') }}
+            {{ states('sensor.aquarea_power_produced') }}
           {%- endif -%}
       heishamon_w_consumption:
-        friendly_name: "Heishamon Energy Consumption"
+        friendly_name: "Aquarea Energy Consumption"
         unit_of_measurement: 'W'
         value_template: >-
-          {%- if states('sensor.heishamon_aquarea_dhw_power_consumed') != "0" -%}
-            {{ states('sensor.heishamon_aquarea_dhw_power_consumed') }}
+          {%- if states('sensor.aquarea_dhw_power_consumed') != "0" -%}
+            {{ states('sensor.aquarea_dhw_power_consumed') }}
           {%- else -%}
-            {{ states('sensor.heishamon_aquarea_power_consumed') }}
+            {{ states('sensor.aquarea_power_consumed') }}
           {%- endif -%}
 
 
@@ -584,7 +587,7 @@ sensor:
 switch:
 #Turn on/off holiday mode
   - platform: mqtt
-    name: Heishamon Aquarea Holiday Mode
+    name: Aquarea Holiday Mode
     command_topic: "panasonic_heat_pump/SetHolidayMode"
     state_topic: "panasonic_heat_pump/sdc/Holiday_Mode_State"
     qos: 0
@@ -594,7 +597,7 @@ switch:
   
 #Turn on/off heatpump  
   - platform: mqtt
-    name: Heishamon Aquarea Power
+    name: Aquarea Main Power
     command_topic: "panasonic_heat_pump/SetHeatpump"
     state_topic: "panasonic_heat_pump/sdc/Heatpump_State"
     qos: 0
@@ -603,7 +606,7 @@ switch:
     retain: false
 
   - platform: mqtt
-    name: Heishamon Aquarea Force DHW Mode
+    name: Aquarea Force DHW Mode
     command_topic: "panasonic_heat_pump/SetForceDHW"
     state_topic: "panasonic_heat_pump/sdc/Force_DHW_State"
     qos: 0

--- a/Integrations/Home Assistant/heishamon.yaml
+++ b/Integrations/Home Assistant/heishamon.yaml
@@ -26,7 +26,7 @@ automation:
   - alias: Set quiet level selector
     trigger:
       platform: mqtt
-      topic: "heishamon_heat_pump/sdc/Quiet_Mode_Level"
+      topic: "panasonic_heat_pump/sdc/Quiet_Mode_Level"
     action:
       service: input_select.select_option
       data_template:
@@ -46,7 +46,7 @@ automation:
     action:
       service: mqtt.publish
       data_template:
-        topic: heishamon_heat_pump/SetQuietMode
+        topic: panasonic_heat_pump/SetQuietMode
         retain: false #IMPORTANT! ALWAYS set retain flag false for commands!
         payload_template: >-
           {%- if states('input_select.heishamon_quietmode') == "Off" -%}
@@ -59,7 +59,7 @@ automation:
   - alias: Set powerful level selector
     trigger:
       platform: mqtt
-      topic: "heishamon_heat_pump/sdc/Powerful_Mode_Time"
+      topic: "panasonic_heat_pump/sdc/Powerful_Mode_Time"
     action:
       service: input_select.select_option
       data_template:
@@ -79,7 +79,7 @@ automation:
     action:
       service: mqtt.publish
       data_template:
-        topic: heishamon_heat_pump/SetPowerfulMode
+        topic: panasonic_heat_pump/SetPowerfulMode
         retain: false #IMPORTANT! ALWAYS set retain flag false for commands!
         payload_template: >-
           {%- if states('input_select.heishamon_powermode') == "Off" -%}
@@ -92,7 +92,7 @@ automation:
   - alias: Set heatmode selector
     trigger:
       platform: mqtt
-      topic: "heishamon_heat_pump/sdc/Operating_Mode_State"
+      topic: "panasonic_heat_pump/sdc/Operating_Mode_State"
     action:
       service: input_select.select_option
       data_template:
@@ -114,7 +114,7 @@ automation:
     action:
       service: mqtt.publish
       data_template:
-        topic: heishamon_heat_pump/SetOperationMode
+        topic: panasonic_heat_pump/SetOperationMode
         retain: false #IMPORTANT! ALWAYS set retain flag false for commands!
         payload_template: >-
           {%- if states('input_select.heishamon_heatmode') == "Heat" -%}
@@ -129,7 +129,7 @@ automation:
   - alias: Set heatshift selector
     trigger:
       platform: mqtt
-      topic: "heishamon_heat_pump/sdc/Z1_Heat_Request_Temp"
+      topic: "panasonic_heat_pump/sdc/Z1_Heat_Request_Temp"
     action:
       service: input_number.set_value
       data_template:
@@ -145,7 +145,7 @@ automation:
     action:
       service: mqtt.publish
       data_template:
-        topic: heishamon_heat_pump/SetZ1HeatRequestTemperature
+        topic: panasonic_heat_pump/SetZ1HeatRequestTemperature
         retain: false #IMPORTANT! ALWAYS set retain flag false for commands!
         payload_template: >-
           {{ "%.0f" % (states('input_number.heishamon_heatshift') | int) }}
@@ -154,7 +154,7 @@ automation:
   - alias: Set tank target temperature selector
     trigger:
       platform: mqtt
-      topic: "heishamon_heat_pump/sdc/DHW_Target_Temp"
+      topic: "panasonic_heat_pump/sdc/DHW_Target_Temp"
     action:
       service: input_number.set_value
       data_template:
@@ -170,7 +170,7 @@ automation:
     action:
       service: mqtt.publish
       data_template:
-        topic: heishamon_heat_pump/SetDHWTemp
+        topic: panasonic_heat_pump/SetDHWTemp
         retain: false #IMPORTANT! ALWAYS set retain flag false for commands!
         payload_template: >-
           {{ "%.0f" % (states('input_number.heishamon_tank_temp') | int) }}
@@ -224,7 +224,7 @@ sensor:
   #TOP0 - Power state
   - platform: mqtt
     name: Heishamon Aquarea Power State
-    state_topic: "heishamon_heat_pump/sdc/Heatpump_State"
+    state_topic: "panasonic_heat_pump/sdc/Heatpump_State"
     value_template: >-
       {%- if value == "0" -%}
         Off
@@ -235,13 +235,13 @@ sensor:
   #TOP1 - Pumpflow
   - platform: mqtt
     name: Heishamon Aquarea Pump Flow
-    state_topic: "heishamon_heat_pump/sdc/Pump_Flow"
+    state_topic: "panasonic_heat_pump/sdc/Pump_Flow"
     unit_of_measurement: 'L/min'
 
   #TOP2 - Force DHW State
   - platform: mqtt
     name: Heishamon Aquarea Force DHW Mode
-    state_topic: "heishamon_heat_pump/sdc/Force_DHW_State"
+    state_topic: "panasonic_heat_pump/sdc/Force_DHW_State"
     value_template: >-
       {%- if value == "0" -%}
         Off
@@ -252,7 +252,7 @@ sensor:
   #TOP4 - Heat mode (Hot water, Heat or Hot water + heat)
   - platform: mqtt
     name: Heishamon Aquarea Mode
-    state_topic: "heishamon_heat_pump/sdc/Operating_Mode_State"
+    state_topic: "panasonic_heat_pump/sdc/Operating_Mode_State"
     value_template: >-
       {%- if value == "0" -%}
         Heat
@@ -273,72 +273,72 @@ sensor:
   #TOP5 - Water inlet temp
   - platform: mqtt
     name: Heishamon Aquarea Inlet Temperature
-    state_topic: "heishamon_heat_pump/sdc/Main_Inlet_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Main_Inlet_Temp"
     unit_of_measurement: '°C'
 
   #TOP6 - Water outlet temp
   - platform: mqtt
     name: Heishamon Aquarea Outlet Temperature
-    state_topic: "heishamon_heat_pump/sdc/Main_Outlet_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Main_Outlet_Temp"
     unit_of_measurement: '°C'
 
   #TOP7 - Water outlet target temp
   - platform: mqtt
     name: Heishamon Aquarea Outlet Target Temperature
-    state_topic: "heishamon_heat_pump/sdc/Main_Target_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Main_Target_Temp"
     unit_of_measurement: '°C'
 
   #TOP8 - Compressor frequency
   - platform: mqtt
     name: Heishamon Aquarea Compressor Frequency
-    state_topic: "heishamon_heat_pump/sdc/Compressor_Freq"
+    state_topic: "panasonic_heat_pump/sdc/Compressor_Freq"
     unit_of_measurement: 'Hz'
 
   #TOP9 - Tank set temperature
   - platform: mqtt
     name: Heishamon Aquarea Tank Set Temperature
-    state_topic: "heishamon_heat_pump/sdc/DHW_Target_Temp"
+    state_topic: "panasonic_heat_pump/sdc/DHW_Target_Temp"
     unit_of_measurement: '°C'
 
   #TOP10 - Tank current temperature
   - platform: mqtt
     name: Heishamon Aquarea Actual Tank Temperature
-    state_topic: "heishamon_heat_pump/sdc/DHW_Temp"
+    state_topic: "panasonic_heat_pump/sdc/DHW_Temp"
     unit_of_measurement: '°C'
 
   #TOP11 - Compressor Operating Time
   - platform: mqtt
     name: Heishamon Aquarea Compressor Operating Hours
-    state_topic: "heishamon_heat_pump/sdc/Operations_Hours"
+    state_topic: "panasonic_heat_pump/sdc/Operations_Hours"
     unit_of_measurement: 'Hours'
 
   #TOP12 - Compressor On/Off cycle number
   - platform: mqtt
     name: Heishamon Aquarea Compressor Start/Stop Counter
-    state_topic: "heishamon_heat_pump/sdc/Operations_Counter"
+    state_topic: "panasonic_heat_pump/sdc/Operations_Counter"
 
   #TOP14 - Outdoor unit ambient temperature
   - platform: mqtt
     name: Heishamon Aquarea Outdoor Ambient
-    state_topic: "heishamon_heat_pump/sdc/Outside_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Outside_Temp"
     unit_of_measurement: '°C'
 
   #TOP15 - Heating power produced
   - platform: mqtt
     name: Heishamon Aquarea Power Produced
-    state_topic: "heishamon_heat_pump/sdc/Heat_Energy_Production"
+    state_topic: "panasonic_heat_pump/sdc/Heat_Energy_Production"
     unit_of_measurement: 'W'
 
   #TOP16 - Heating power consumed
   - platform: mqtt
     name: Heishamon Aquarea Power Consumed
-    state_topic: "heishamon_heat_pump/sdc/Heat_Energy_Consumption"
+    state_topic: "panasonic_heat_pump/sdc/Heat_Energy_Consumption"
     unit_of_measurement: 'W'
 
   #TOP17 - Heating powerfull mode
   - platform: mqtt
     name: Heishamon Aquarea Powerful Mode
-    state_topic: "heishamon_heat_pump/sdc/Powerful_Mode_Time"
+    state_topic: "panasonic_heat_pump/sdc/Powerful_Mode_Time"
     unit_of_measurement: 'Min'
     value_template: >-
       {{ (value | int) * 30 }}
@@ -346,7 +346,7 @@ sensor:
   #TOP18 - Heating quiet mode
   - platform: mqtt
     name: Heishamon Aquarea Quiet Mode
-    state_topic: "heishamon_heat_pump/sdc/Quiet_Mode_Level"
+    state_topic: "panasonic_heat_pump/sdc/Quiet_Mode_Level"
     value_template: >-
       {%- if value == "4" -%}
         Scheduled
@@ -357,7 +357,7 @@ sensor:
   #TOP19 - Holiday Mode
   - platform: mqtt
     name: Heishamon Aquarea Holiday Mode
-    state_topic: "heishamon_heat_pump/sdc/Holiday_Mode_State"
+    state_topic: "panasonic_heat_pump/sdc/Holiday_Mode_State"
     value_template: >-
       {%- if value == "0" -%}
         Off
@@ -368,7 +368,7 @@ sensor:
   #TOP20 - 3-way valve state
   - platform: mqtt
     name: Heishamon Aquarea 3-way Valve
-    state_topic: "heishamon_heat_pump/sdc/ThreeWay_Valve_State"
+    state_topic: "panasonic_heat_pump/sdc/ThreeWay_Valve_State"
     value_template: >-
       {%- if value == "0" -%}
         Room
@@ -379,13 +379,13 @@ sensor:
   #TOP21 - Outside pipe temp
   - platform: mqtt
     name: Heishamon Aquarea Outdoor Pipe Temperature
-    state_topic: "heishamon_heat_pump/sdc/Outside_Pipe_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Outside_Pipe_Temp"
     unit_of_measurement: '°C'
 
   #TOP26 - Defrost state
   - platform: mqtt
     name: Heishamon Aquarea Defrost State
-    state_topic: "heishamon_heat_pump/sdc/Defrosting_State"
+    state_topic: "panasonic_heat_pump/sdc/Defrosting_State"
     value_template: >-
       {%- if value == "0" -%}
         Inactive
@@ -396,72 +396,72 @@ sensor:
   #TOP27 - Heatshift Temperature
   - platform: mqtt
     name: Heishamon Aquarea Heatshift Temperature
-    state_topic: "heishamon_heat_pump/sdc/Z1_Heat_Request_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Z1_Heat_Request_Temp"
     unit_of_measurement: '°C'
 
   #TOP40 - DHW power produced
   - platform: mqtt
     name: Heishamon Aquarea DHW Power Produced
-    state_topic: "heishamon_heat_pump/sdc/DHW_Energy_Production"
+    state_topic: "panasonic_heat_pump/sdc/DHW_Energy_Production"
     unit_of_measurement: 'W'
 
   #TOP41 - DHW power consumed
   - platform: mqtt
     name: Heishamon Aquarea DHW Power Consumed
-    state_topic: "heishamon_heat_pump/sdc/DHW_Energy_Consumption"
+    state_topic: "panasonic_heat_pump/sdc/DHW_Energy_Consumption"
     unit_of_measurement: 'W'
 
   #TOP44 - Last active error
   - platform: mqtt
     name: Heishamon Aquarea Last Error
-    state_topic: "heishamon_heat_pump/sdc/Error"
+    state_topic: "panasonic_heat_pump/sdc/Error"
 
   #TOP49 - Water HEX Outlet temp
   - platform: mqtt
     name: Heishamon Aquarea Main HEX Outlet Temperature
-    state_topic: "heishamon_heat_pump/sdc/Main_Hex_Outlet_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Main_Hex_Outlet_Temp"
     unit_of_measurement: '°C'
 
   #TOP50 - Discharge temp
   - platform: mqtt
     name: Heishamon Aquarea Discharge Temperature
-    state_topic: "heishamon_heat_pump/sdc/Discharge_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Discharge_Temp"
     unit_of_measurement: '°C'
 
   #TOP51 - Inside Pipe temp
   - platform: mqtt
     name: Heishamon Aquarea Inside Pipe Temperature
-    state_topic: "heishamon_heat_pump/sdc/Inside_Pipe_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Inside_Pipe_Temp"
     unit_of_measurement: '°C'
 
   #TOP52 - Defrost temp
   - platform: mqtt
     name: Heishamon Aquarea Defrost Temperature
-    state_topic: "heishamon_heat_pump/sdc/Defrost_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Defrost_Temp"
     unit_of_measurement: '°C'
 
   #TOP53 - Eva Outlet temp
   - platform: mqtt
     name: Heishamon Aquarea Eva Outlet Temperature
-    state_topic: "heishamon_heat_pump/sdc/Eva_Outlet_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Eva_Outlet_Temp"
     unit_of_measurement: '°C'
 
   #TOP54 - Bypass Outlet temp
   - platform: mqtt
     name: Heishamon Aquarea Bypass Outlet Temperature
-    state_topic: "heishamon_heat_pump/sdc/Bypass_Outlet_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Bypass_Outlet_Temp"
     unit_of_measurement: '°C'
 
   #TOP55 - lpm temp
   - platform: mqtt
     name: Heishamon Aquarea Ipm Temperature
-    state_topic: "heishamon_heat_pump/sdc/Ipm_Temp"
+    state_topic: "panasonic_heat_pump/sdc/Ipm_Temp"
     unit_of_measurement: '°C'
 
   #TOP58 - Tank electric heater allowed state
   - platform: mqtt
     name: Heishamon Aquarea Tank Heater Enabled
-    state_topic: "heishamon_heat_pump/sdc/DHW_Heater_State"
+    state_topic: "panasonic_heat_pump/sdc/DHW_Heater_State"
     value_template: >-
       {%- if value == "0" -%}
         Off
@@ -472,7 +472,7 @@ sensor:
   #TOP59 - Water electric heater allowed state
   - platform: mqtt
     name: Heishamon Aquarea Room Heater Enabled
-    state_topic: "heishamon_heat_pump/sdc/Room_Heater_State"
+    state_topic: "panasonic_heat_pump/sdc/Room_Heater_State"
     value_template: >-
       {%- if value == "0" -%}
         Off
@@ -483,7 +483,7 @@ sensor:
   #TOP60 - Internal heater state
   - platform: mqtt
     name: Heishamon Aquarea Internal Heater State
-    state_topic: "heishamon_heat_pump/sdc/Internal_Heater_State"
+    state_topic: "panasonic_heat_pump/sdc/Internal_Heater_State"
     value_template: >-
       {%- if value == "0" -%}
         Off
@@ -494,7 +494,7 @@ sensor:
   #TOP61 - External heater state
   - platform: mqtt
     name: Heishamon Aquarea External Heater State
-    state_topic: "heishamon_heat_pump/sdc/External_Heater_State"
+    state_topic: "panasonic_heat_pump/sdc/External_Heater_State"
     value_template: >-
       {%- if value == "0" -%}
         Off
@@ -505,37 +505,37 @@ sensor:
   #TOP62 - Fan1 speed
   - platform: mqtt
     name: Heishamon Aquarea Fan 1 Speed
-    state_topic: "heishamon_heat_pump/sdc/Fan1_Motor_Speed"
+    state_topic: "panasonic_heat_pump/sdc/Fan1_Motor_Speed"
     unit_of_measurement: "R/min"
 
   #TOP63 - Fan2 speed
   - platform: mqtt
     name: Heishamon Aquarea Fan 2 Speed
-    state_topic: "heishamon_heat_pump/sdc/Fan2_Motor_Speed"
+    state_topic: "panasonic_heat_pump/sdc/Fan2_Motor_Speed"
     unit_of_measurement: "R/min"
 
   #TOP64 - High pressure
   - platform: mqtt
     name: Heishamon Aquarea High pressure
-    state_topic: "heishamon_heat_pump/sdc/High_Pressure"
+    state_topic: "panasonic_heat_pump/sdc/High_Pressure"
     unit_of_measurement: "Kgf/cm2"
 
   #TOP65 - Pump speed
   - platform: mqtt
     name: Heishamon Aquarea Pump Speed
-    state_topic: "heishamon_heat_pump/sdc/Pump_Speed"
+    state_topic: "panasonic_heat_pump/sdc/Pump_Speed"
     unit_of_measurement: "R/min"
 
   #TOP66 - Low pressure
   - platform: mqtt
     name: Heishamon Aquarea Low pressure
-    state_topic: "heishamon_heat_pump/sdc/Low_Pressure"
+    state_topic: "panasonic_heat_pump/sdc/Low_Pressure"
     unit_of_measurement: "Kgf/cm2"
 
   #TOP66 - Compressor Current
   - platform: mqtt
     name: Heishamon Aquarea Compressor Current
-    state_topic: "heishamon_heat_pump/sdc/Compressor_Current"
+    state_topic: "panasonic_heat_pump/sdc/Compressor_Current"
     unit_of_measurement: "A"
 
   #### SENSORS BELOW ARE NOT IN FIRMWARE ####
@@ -585,8 +585,8 @@ switch:
 #Turn on/off holiday mode
   - platform: mqtt
     name: Heishamon Aquarea Holiday Mode
-    command_topic: "heishamon_heat_pump/SetHolidayMode"
-    state_topic: "heishamon_heat_pump/sdc/Holiday_Mode_State"
+    command_topic: "panasonic_heat_pump/SetHolidayMode"
+    state_topic: "panasonic_heat_pump/sdc/Holiday_Mode_State"
     qos: 0
     payload_on: "1"
     payload_off: "0"
@@ -595,8 +595,8 @@ switch:
 #Turn on/off heatpump  
   - platform: mqtt
     name: Heishamon Aquarea Power
-    command_topic: "heishamon_heat_pump/SetHeatpump"
-    state_topic: "heishamon_heat_pump/sdc/Heatpump_State"
+    command_topic: "panasonic_heat_pump/SetHeatpump"
+    state_topic: "panasonic_heat_pump/sdc/Heatpump_State"
     qos: 0
     payload_on: "1"
     payload_off: "0"
@@ -604,8 +604,8 @@ switch:
 
   - platform: mqtt
     name: Heishamon Aquarea Force DHW Mode
-    command_topic: "heishamon_heat_pump/SetForceDHW"
-    state_topic: "heishamon_heat_pump/sdc/Force_DHW_State"
+    command_topic: "panasonic_heat_pump/SetForceDHW"
+    state_topic: "panasonic_heat_pump/sdc/Force_DHW_State"
     qos: 0
     payload_on: "1"
     payload_off: "0"


### PR DESCRIPTION
This pull request does the following things:
- fix the COP calculation
- change the default topic from heishamon_heat_pump to panasonic_heat_pump
- shorten the sensor names, so they will actually be shown on the Home Assistant UI in a nicer way