### PR TITLE
Fix for S0 kWh counting in heishamon.yaml

### DIFF
--- a/Integrations/Home Assistant/heishamon.yaml
+++ b/Integrations/Home Assistant/heishamon.yaml
@@ -558,8 +558,10 @@ sensor:
 
   - platform: mqtt
     name: Aquarea Metered Power Consumption Total
-    state_topic: "panasonit_heat_pump/s0/Watthour/1"
+    state_topic: "panasonic_heat_pump/s0/Watthour/1"
     unit_of_measurement: 'kWh'
+    value_template: >-
+      {{ (value | int) / 1000}}'
 
   #S0 kWh Meter 2 - Assumed to measure the backup heater consumption
   - platform: mqtt
@@ -569,8 +571,10 @@ sensor:
 
   - platform: mqtt
     name: Aquarea Metered Backup Heater Power Consumption Total
-    state_topic: "panasonit_heat_pump/s0/Watthour/2"
+    state_topic: "panasonic_heat_pump/s0/Watthour/2"
     unit_of_measurement: 'kWh'
+    value_template: >-
+      {{ (value | int) / 1000}}
 
   #### SENSORS BELOW ARE NOT IN FIRMWARE ####
   #COP Calculations


### PR DESCRIPTION
Fix for a spelling mistake and a missing conversion from Wh to kWh for the S0 energy counting in heishamon.yaml