### PR TITLE
Update heishamon.yaml

### DIFF
--- a/Integrations/Home Assistant/heishamon.yaml
+++ b/Integrations/Home Assistant/heishamon.yaml
@@ -149,6 +149,32 @@ automation:
         retain: false #IMPORTANT! ALWAYS set retain flag false for commands!
         payload_template: >-
           {{ "%.0f" % (states('input_number.heishamon_heatshift') | int) }}
+          
+   
+  #Fetches heatshift temperature from status and sets the selector accordingly
+  - alias: Set heatshift2 selector
+    trigger:
+      platform: mqtt
+      topic: "panasonic_heat_pump/main/Z2_Heat_Request_Temp"
+    action:
+      service: input_number.set_value
+      data_template:
+        entity_id: input_number.heishamon_heatshift2
+        value: >-
+          {{ "%.1f" % (trigger.payload | int) }}
+
+  #Sets heatshift2 temperature to the selected value
+  - alias: Set heatshift2
+    trigger:
+      platform: state
+      entity_id: input_number.heishamon_heatshift2
+    action:
+      service: mqtt.publish
+      data_template:
+        topic: panasonic_heat_pump/commands/SetZ2HeatRequestTemperature
+        retain: false #IMPORTANT! ALWAYS set retain flag false for commands!
+        payload_template: >-
+          {{ "%.0f" % (states('input_number.heishamon_heatshift2') | int) }}
 
   #Fetches tank target temperature from status and sets the selector accordingly
   - alias: Set tank target temperature selector
@@ -175,6 +201,42 @@ automation:
         payload_template: >-
           {{ "%.0f" % (states('input_number.heishamon_tank_temp') | int) }}
 
+  #Fetches zones from status and sets the selector accordingly
+  - alias: Set zones selector
+    trigger:
+      platform: mqtt
+      topic: "panasonic_heat_pump/main/Zones_State"
+    action:
+      service: input_select.select_option
+      data_template:
+        entity_id: input_select.heishamon_zones
+        option: >-
+          {%- if trigger.payload == "0" -%}
+            Zone1
+          {%- elif trigger.payload == "1" -%}
+            Zone2
+          {%- elif trigger.payload == "2" -%}
+            Zone1+2
+          {%- endif -%}
+
+  #Sets zones to the selected value
+  - alias: Set zones
+    trigger:
+      platform: state
+      entity_id: input_select.heishamon_zones
+    action:
+      service: mqtt.publish
+      data_template:
+        topic: panasonic_heat_pump/commands/SetZones
+        retain: false #IMPORTANT! ALWAYS set retain flag false for commands!
+        payload_template: >-
+          {%- if states('input_select.heishamon_zones') == "Zone1" -%}
+            0
+          {%- elif states('input_select.heishamon_zones') == "Zone2" -%}
+            1
+          {%- elif states('input_select.heishamon_zones') == "Zone1+2" -%}
+            2
+          {%- endif -%}
 
 # input_number #
 ################
@@ -186,6 +248,12 @@ input_number:
     step: 1
 
   heishamon_heatshift:
+    name: Set Heatshift Temperature
+    min: -5
+    max: 5
+    step: 1
+  
+  heishamon_heatshift2:
     name: Set Heatshift Temperature
     min: -5
     max: 5
@@ -217,6 +285,13 @@ input_select:
       - Heat+DHW
       - Heat
       - DHW
+      
+  heishamon_zones:
+    name: Set Zone selection
+    options:
+      - 'Zone1'
+      - 'Zone2'
+      - 'Zone1+2'
 
 # sensor #
 ##########
@@ -413,6 +488,11 @@ sensor:
     state_topic: "panasonic_heat_pump/main/Z1_Heat_Request_Temp"
     unit_of_measurement: '°C'
 
+  #TOP34 - Heatshift Temperature
+  - name: Aquarea Z2 Temperature
+    state_topic: "panasonic_heat_pump/main/Z2_Heat_Request_Temp"
+    unit_of_measurement: '°C'
+
   #TOP40 - DHW power produced
   - platform: mqtt
     name: Aquarea DHW Power Produced
@@ -558,6 +638,18 @@ sensor:
     name: Aquarea Compressor Current
     state_topic: "panasonic_heat_pump/main/Compressor_Current"
     unit_of_measurement: "A"
+    
+  #TOP94 - Zone state
+  - name: Aquarea Zones state
+    state_topic: "panasonic_heat_pump/main/Zones_State"
+    value_template: >-
+      {%- if value == "0" -%}
+        Zone1
+      {%- elif value == "1" -%}
+        Zone2
+      {%- elif value == "2" -%}
+        Zone1+2
+      {%- endif -%}
 
   ##1-Wire - Example, replace with correct sensor ID
   #- platform: mqtt


### PR DESCRIPTION
added 2 zones selector with second heatshift setting for zone 2
Also added topic for 2nd heat request temperature and zone selection.
Kept zone 1 naming the same for people updating.

Would like to build in a selection menu at the beginning so people can choose:
DHW yes/no
zones: 1/2
Cool: yes/no
Thermostat / water temp
maybe more?
And would like to change settings (like temperatures "input number" section) based on options in the beginning and add or remove topics/switches based on that.
If anyone has an idea and would be able to get me started. I am happy to continue with that.

It is my first pull request, so if I am doing something wrong. Let me know ;)