### PR TITLE
Increased length of MQTT topic base

### DIFF
--- a/HeishaMon/webfunctions.h
+++ b/HeishaMon/webfunctions.h
@@ -35,7 +35,7 @@ struct settingsStruct {
   char mqtt_port[6] = "1883";
   char mqtt_username[64];
   char mqtt_password[64];
-  char mqtt_topic_base[40] = "panasonic_heat_pump";
+  char mqtt_topic_base[128] = "panasonic_heat_pump";
   char ntp_servers[254] = "pool.ntp.org";
 
   bool listenonly = false; //listen only so heishamon can be installed parallel to cz-taw1, set commands will not work though


### PR DESCRIPTION
The original 40 chars length is too short for my use case of my MQTT broker, it looks like working in my environment.

I did not perform regression tests with released versions, so it maybe broke compatibility or the update process.