### PR TITLE
Longer server name up to 64 characters

### DIFF
--- a/HeishaMon/webfunctions.h
+++ b/HeishaMon/webfunctions.h
@@ -31,7 +31,7 @@ struct settingsStruct {
   char wifi_password[65] = "";
   char wifi_hostname[40] = "HeishaMon";
   char ota_password[40] = "heisha";
-  char mqtt_server[40];
+  char mqtt_server[64];
   char mqtt_port[6] = "1883";
   char mqtt_username[64];
   char mqtt_password[64];


### PR DESCRIPTION
Extender server name length to 64

40 chars is not enough for mqtt server name.
Service hivemq.cloud generates server name thats length is 52.