### PR TITLE
Incorrect initialization of the memory

### DIFF
--- a/HeishaMon/rules.cpp
+++ b/HeishaMon/rules.cpp
@@ -575,8 +575,8 @@ static int8_t vm_value_set(struct rules_t *obj) {
         }
       }
 
-      memset(&cmd, 256, 0);
-      memset(&log_msg, 256, 0);
+      memset(&cmd, 0, sizeof(cmd));
+      memset(&log_msg, 0, sizeof(log_msg));
 
       if(heishamonSettings.optionalPCB) {
         //optional commands


### PR DESCRIPTION
When initializing the memory, the parameters for the memset() function were swapped and the memory was not initialized.

(the compiler warnings had pointed this out)