### PR TITLE
Add WH-MXC12J9E8 type info

### DIFF
--- a/HeatPumpType.md
+++ b/HeatPumpType.md
@@ -54,6 +54,7 @@ Assuming that bytes from #129 to #138 are unique for each model of Aquarea heat 
 |47 | E2 CF 0C 74 09 12 D0 0C 95 05 | WH-ADC0916H9E8 | WH-UX12HE8 | KIT-AXC12HE8 | 12 | 3ph | T-CAP - All-In-One |
 |48 | E2 D5 0B 34 99 83 92 0C 28 98 | WH-SDC0509L3E5 |  WH-WDG07LE5 | KIT-WC07L3E5 | 7 | 1 ph | HP - split L-series 3kW elec heating |
 |49 | E2 CF 0D 77 09 12 D0 0C 05 11 | WH-SXC09H3E5 | WH-UX09HE5 | KIT-WXC09H3E5 | 9 | 1ph | T-CAP |
+|50 | 94 04 79 7B C1 0B 7E 7C 1F 7C | Monoblock | WH-MXC12J9E8 | Monoblock | 12 | 3ph | T-CAP |
 
 All bytes are used for Heat Pump model identification in the code.
 


### PR DESCRIPTION
HeishaMon confirms to work on heatpump with model number: WH-MXC12J9E8.

Complete data block:

```
(4031148): data: 71 C8 01 10 56 55 62 49 00 55 00 01 00 00 00 00 00 00 00 00 59 15 13 55 56 15 55 55 69 1A 00 00 
(4031149): data: 00 00 00 00 00 00 94 94 80 8A B2 71 71 76 99 00 00 00 00 00 00 00 00 00 00 00 80 85 15 8A 85 85 
(4031150): data: D0 7B 78 1F 7E 1F 1F 79 79 8D 8D AD A3 7B 8F B7 A3 7B 8F 98 85 7B 94 8A 94 9E 8A 8A 94 9E 82 99 
(4031151): data: 94 04 79 7B C1 0B 7E 7C 1F 7C 7E 00 00 00 55 E5 55 21 73 15 59 05 0C 13 69 01 00 00 00 00 00 00 
(4031151): data: 00 32 D4 0B 88 84 73 90 0C 85 84 93 00 B3 8A 9D 9F 32 32 A6 A8 32 32 32 94 A6 9E A7 93 99 8A 8B 
(4031152): data: 95 98 98 34 01 01 01 00 00 98 0B 3E 76 01 01 79 79 01 01 17 26 00 25 07 00 01 00 00 01 00 00 0D 
(4031153): data: 02 01 01 01 01 01 01 02 00 00 CA
```