### PR TITLE
Asynchronous 1-wire reading

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Build binary
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 
 env:
   ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS: "http://arduino.esp8266.com/stable/package_esp8266com_index.json https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Build binary
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   ARDUINO_BOARD_MANAGER_ADDITIONAL_URLS: "http://arduino.esp8266.com/stable/package_esp8266com_index.json https://espressif.github.io/arduino-esp32/package_esp32_dev_index.json"

--- a/HeishaMon/commands.cpp
+++ b/HeishaMon/commands.cpp
@@ -12,6 +12,7 @@ const char* mqtt_topic_xvalues PROGMEM = "extra";
 const char* mqtt_topic_commands PROGMEM = "commands";
 const char* mqtt_topic_pcbvalues PROGMEM = "optional";
 const char* mqtt_topic_1wire PROGMEM = "1wire";
+const char* mqtt_topic_1wire_alias PROGMEM = "1wire_alias";
 const char* mqtt_topic_s0 PROGMEM = "s0";
 const char* mqtt_logtopic PROGMEM = "log";
 

--- a/HeishaMon/commands.h
+++ b/HeishaMon/commands.h
@@ -22,6 +22,7 @@ extern const char* mqtt_topic_xvalues;
 extern const char* mqtt_topic_commands;
 extern const char* mqtt_topic_pcbvalues;
 extern const char* mqtt_topic_1wire;
+extern const char* mqtt_topic_1wire_alias;
 extern const char* mqtt_topic_s0;
 extern const char* mqtt_topic_pcb;
 extern const char* mqtt_logtopic;

--- a/HeishaMon/dallas.cpp
+++ b/HeishaMon/dallas.cpp
@@ -71,6 +71,7 @@ void readNewDallasTemp(PubSubClient &mqtt_client, void (*log_message)(char*), ch
   char log_msg[256];
   char mqtt_topic[256];
   char valueStr[80];
+  char alias[80];
   bool updatenow = false;
 
   if ((lastalldatatime_dallas == 0) || ((unsigned long)(millis() - lastalldatatime_dallas) >  (1000 * updateAllDallasTime))) {
@@ -96,8 +97,12 @@ void readNewDallasTemp(PubSubClient &mqtt_client, void (*log_message)(char*), ch
           if (true) {
             sprintf_P(valueStr, PSTR("%.2f"), actDallasData[i].temperature);
             sprintf_P(mqtt_topic, PSTR("%s/%s/%s"), mqtt_topic_base, mqtt_topic_1wire, actDallasData[i].address); mqtt_client.publish(mqtt_topic, valueStr, MQTT_RETAIN_VALUES);
-            sprintf_P(valueStr, PSTR("%s"), actDallasData[i].alias);
-            sprintf_P(mqtt_topic, PSTR("%s/%s/%s/alias"), mqtt_topic_base, mqtt_topic_1wire, actDallasData[i].address); mqtt_client.publish(mqtt_topic, valueStr, MQTT_RETAIN_VALUES);
+            sprintf_P(alias, PSTR("%s"), actDallasData[i].alias);
+            sprintf_P(mqtt_topic, PSTR("%s/%s/%s/alias"), mqtt_topic_base, mqtt_topic_1wire, actDallasData[i].address); mqtt_client.publish(mqtt_topic, alias, MQTT_RETAIN_VALUES);
+            if (strlen(alias) > 0 && alias[0] != '$' && alias[0] != '/' && alias[strlen(alias) - 1] != '/' && strchr(alias, '+') == nullptr && strchr(alias, '#') == nullptr 
+               && strstr(alias, "//") == nullptr) {        
+              sprintf_P(mqtt_topic, PSTR("%s/%s/%s"), mqtt_topic_base, mqtt_topic_1wire_alias, alias); mqtt_client.publish(mqtt_topic, valueStr, MQTT_RETAIN_VALUES);
+            }
           } else {
             sprintf_P(valueStr, PSTR("{\"Temperature\":%.2f,\"Alias\":\"%s\"}"), actDallasData[i].temperature, actDallasData[i].alias);
             sprintf_P(mqtt_topic, PSTR("%s/%s/%s"), mqtt_topic_base, mqtt_topic_1wire, actDallasData[i].address); mqtt_client.publish(mqtt_topic, valueStr, MQTT_RETAIN_VALUES);

--- a/HeishaMon/dallas.cpp
+++ b/HeishaMon/dallas.cpp
@@ -12,7 +12,7 @@
 
 #define MAXTEMPDIFFPERSEC 0.5 // what is the allowed temp difference per second which is allowed (to filter bad values)
 
-#define DALLASASYNC 1 //async dallas yes or no (default no, because async seems to break 1wire sometimes with current code)
+#define DALLASASYNC 1 //async dallas yes or no (default yes)
 
 OneWire oneWire(ONE_WIRE_BUS);
 DallasTemperature DS18B20(&oneWire);


### PR DESCRIPTION
Currently, 1-wire is read synchronously, which means the program is paused for up to 750ms. During this pause, a yield is called, ensuring that WiFi works correctly. However, other issues may arise, such as UART read buffer overflow.
I have modified the code so that everything operates asynchronously.
The previous solution to this problem contained a bug:
  if ((DALLASASYNC) && ((unsigned long)(millis() - dallasTimer) > ((1000 * dallasTimerWait) - 1000)) ) {
    DS18B20.requestTemperatures(); // get temperatures for next run 1 second before getting the temperatures (async)
  }
The author assumed the code would execute only once, while in reality, it was executed multiple times per second before the reading.