### PR TITLE
Make clear how the connection should be made on the Heishamon side

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ CN-NMODE Pin-out (from left to right) \
 2 - 0-5V RX (to heatpump) \
 1 - GND
 
+Note that the TX on these ports should be connected to the TX on the Heishamon and the RX to the RX.
+
 HeishaMon will receive power from the Panasonic over the cable (5v power).
 
 ## Long distance connection


### PR DESCRIPTION
I was [confused about this](https://gathering.tweakers.net/forum/list_message/81135286#81135286), since in my experience TX on one end of the cable gets connected to RX on the other end.

Maybe it would be clearer to change the section to not describe the PINOUT of the CN_CNT and CN_NMODE connectors, but rather the pins they should be connected to on the Heishamon.

(My tests were done with Heishamon v1.3 and Panasonic L series)