### PR TITLE
add KIT-ADC03JE5C-S type info

### DIFF
--- a/HeatPumpType.md
+++ b/HeatPumpType.md
@@ -34,7 +34,7 @@ Assuming that bytes from #129 to #138 are unique for each model of Aquarea heat 
 |27 | C2 D3 0C 34 65 B2 D3 0B 95 65 | Monoblock | WH-MDC07J3E5 | Monoblock | 7 | 1ph | HP (new version?) |
 |28 | C2 D3 0C 33 65 B2 D3 0B 94 65 | Monoblock | WH-MDC05J3E5 | Monoblock | 5 | 1ph | HP (new version) |
 |29 | E2 CF 0B 83 05 12 D0 0D 92 05 | WH-SQC12H9E8 | WH-UQ12HE8 | KIT-WQC12H9E8 | 12 | 3ph | T-CAP - Super Quiet |
-|30 | E2 CF 0C 78 09 12 D0 0B 06 11 | WH-SXC12H6E5 | WH-UX12HE5 | KIT-WXC12H6E5 | 12 | 1ph | T-CAP | 
+|30 | E2 CF 0C 78 09 12 D0 0B 06 11 | WH-SXC12H6E5 | WH-UX12HE5 | KIT-WXC12H6E5 | 12 | 1ph | T-CAP |
 |31 | C2 D3 0C 35 65 B2 D3 0B 96 65 | Monoblock | WH-MDC09J3E5 | Monoblock | 9 | 1ph | HP (new version?) |
 |32 | 32 D4 0B 99 77 62 90 0B 01 78 | Monoblock | WH-MXC09J3E5 | Monoblock | 9 | 1ph | T-CAP
 |33 | 42 D4 0B 15 76 12 D0 0B 10 11 | WH-ADC1216H6E5C | WH-UD12HE5 | KIT-ADC12HE5C-CL | 12 | 1ph| HP - All-In-One Compact |
@@ -56,6 +56,7 @@ Assuming that bytes from #129 to #138 are unique for each model of Aquarea heat 
 |49 | E2 CF 0D 77 09 12 D0 0C 05 11 | WH-SXC09H3E5 | WH-UX09HE5 | KIT-WXC09H3E5 | 9 | 1ph | T-CAP |
 |51 | E2 D5 0C 67 00 83 92 0C 27 98 | WH-ADC0509L3E5AN | WH-WDG05LE5 | KIT-ADC05L3E5AN | 5 | 1ph | HP - split L-series 3kW elec heating - AN |
 |52 | E2 D5 0B 34 99 83 92 0C 27 98 | WH-SDC0509L3E5 | WH-WDG05LE5 | KIT-WC05L3E5 | 5 | 1ph | HP - split L-series 3kW elec heating |
+|53 | 42 D4 0B 83 71 32 D2 0C 44 55 | WH-ADC0309J3E5C | WH-UD03JE5 | KIT-ADC03JE5C-S | 3.2 | 1ph | HP - All-In-One Compact |
 
 All bytes are used for Heat Pump model identification in the code.
 


### PR DESCRIPTION
HeishaMon confirms to work on heatpump with model number: KIT-ADC03JE5C-S.

From Heisha web interface (v3.9):
TOP92	Heat_Pump_Model	42 D4 0B 83 71 32 D2 0C 44 55	Model

Complete data block:
(239136805): data: 71 C8 01 10 56 55 62 49 00 65 00 01 00 00 00 00 00 00 00 00 59 15 12 55 56 15 55 55 59 1A 00 00 
(239136805): data: 00 00 00 00 00 00 80 80 80 8A AB 71 71 96 99 00 00 00 00 00 00 00 00 00 00 00 80 85 15 8A 85 85 
(239136806): data: D0 7B 78 1F 7E 1F 1F 79 79 8D 8D A2 98 80 8F B7 A3 7B 8F 97 85 7B 90 8A 94 9E 8A 8A 94 9E 85 98 
(239136807): data: 93 11 3D 7E C1 0B 7E 7C 1F 7C 7E 00 00 00 55 55 55 01 11 15 59 05 23 12 6A 01 00 00 00 00 00 00 
(239136808): data: 00 42 D4 0B 83 71 32 D2 0C 44 55 9C 00 AA 8B 9A 9C 32 32 9B A7 32 32 32 80 9B 9C AB 9A 9C 88 80 
(239136809): data: 88 61 52 5C 01 05 10 00 00 CD 09 29 58 28 01 18 01 01 01 91 18 00 FF 15 00 06 00 00 01 00 00 04 
(239136810): data: 01 01 08 01 01 01 01 02 00 00 69