### PR TITLE
Decoding of half point Z1_Temp (TOP56) values

### DIFF
--- a/HeishaMon/decode.cpp
+++ b/HeishaMon/decode.cpp
@@ -209,6 +209,24 @@ String getDataValue(char* data, unsigned int Topic_Number) {
     case 12:
       Topic_Value = String(word(data[180], data[179]) - 1);
       break;
+    case 56: {
+        byte cpy;
+        memcpy_P(&cpy, &topicBytes[Topic_Number], sizeof(byte));
+        Input_Byte = data[cpy];
+        Topic_Value = topicFunctions[Topic_Number](Input_Byte);
+        int fractional = (int)(data[119] & 0b11);
+        switch (fractional) {
+          case 1: // fractional .00
+            Topic_Value = Topic_Value + ".0";
+            break;
+          case 3: // fractional .50
+            Topic_Value = Topic_Value + ".5";
+            break;
+          default:
+            break;
+        }
+      }
+      break;
     case 90:
       Topic_Value = String(word(data[186], data[185]) - 1);
       break;


### PR DESCRIPTION
This commit adds decoding of .50 values for the Z1 temp, decoding is done in the same way as the fractional values for water temperatures. I expect that the same can be done for Z2 temp with bit 3 & 4 of byte 119, but I can not test this myself.

I have been running this for 2 weeks and the result are as expected. The temperature now increases and decreases by half degrees now:

![temps](https://github.com/user-attachments/assets/bff39893-f323-4e5f-a7fa-6a030663bc8c)
