### PR TITLE
Bring back S0 in Home Assistant template

### DIFF
--- a/Integrations/Home Assistant/heishamon.yaml
+++ b/Integrations/Home Assistant/heishamon.yaml
@@ -43,6 +43,10 @@
 ## 1.6.1 (3-11-2024)
 ##   Style
 ##   - Fix indentation and remove trailing spaces
+## 1.6.2 (2-6-2025)
+##   Added
+##   - Bring back the S0 readings as examples (they're more accurate and people might have other uses for them)
+
 
 # Automations #
 ###############
@@ -767,31 +771,31 @@ mqtt:
 
     # The following S0 topics are only available if S0 is enabled.
     #
-    #S0 kWh Meter 1 - Assumed to measure the heat pump consumption
-    - name: Aquarea Metered Power Consumption
-      state_topic: "panasonic_heat_pump/s0/Watt/1"
-      unit_of_measurement: "W"
-      state_class: "measurement"
+    #S0 kWh Meter 1 Example - Assumed to measure the heat pump consumption
+    #- name: Aquarea Metered Power Consumption
+    #  state_topic: "panasonic_heat_pump/s0/Watt/1"
+    #  unit_of_measurement: "W"
+    #  state_class: "measurement"
 
-    - name: Aquarea Metered Power Consumption Total
-      state_topic: "panasonic_heat_pump/s0/WatthourTotal/1"
-      unit_of_measurement: "kWh"
-      value_template: >-
-        {{ (value | int) / 1000}}
-      state_class: "measurement"
+    #- name: Aquarea Metered Power Consumption Total
+    #  state_topic: "panasonic_heat_pump/s0/WatthourTotal/1"
+    #  unit_of_measurement: "kWh"
+    #  value_template: >-
+    #    {{ (value | int) / 1000}}
+    #  state_class: "measurement"
 
-    #S0 kWh Meter 2 - Assumed to measure the backup heater consumption
-    - name: Aquarea Metered Backup Heater Power Consumption
-      state_topic: "panasonic_heat_pump/s0/Watt/2"
-      unit_of_measurement: "W"
-      state_class: "measurement"
+    #S0 kWh Meter 2 Example - Assumed to measure the backup heater consumption
+    #- name: Aquarea Metered Backup Heater Power Consumption
+    #  state_topic: "panasonic_heat_pump/s0/Watt/2"
+    #  unit_of_measurement: "W"
+    #  state_class: "measurement"
 
-    - name: Aquarea Metered Backup Heater Power Consumption Total
-      state_topic: "panasonic_heat_pump/s0/WatthourTotal/2"
-      unit_of_measurement: "kWh"
-      value_template: >-
-        {{ (value | int) / 1000}}
-      state_class: "measurement"
+    #- name: Aquarea Metered Backup Heater Power Consumption Total
+    #  state_topic: "panasonic_heat_pump/s0/WatthourTotal/2"
+    #  unit_of_measurement: "kWh"
+    #  value_template: >-
+    #    {{ (value | int) / 1000}}
+    #  state_class: "measurement"
 
   # switch #
   ##########

--- a/Integrations/Home Assistant/heishamon.yaml
+++ b/Integrations/Home Assistant/heishamon.yaml
@@ -765,6 +765,34 @@ mqtt:
     #  unit_of_measurement: '°C'
     #  value_template: '{{value | round(1) }}'
 
+    # The following S0 topics are only available if S0 is enabled.
+    #
+    #S0 kWh Meter 1 - Assumed to measure the heat pump consumption
+    - name: Aquarea Metered Power Consumption
+      state_topic: "panasonic_heat_pump/s0/Watt/1"
+      unit_of_measurement: "W"
+      state_class: "measurement"
+
+    - name: Aquarea Metered Power Consumption Total
+      state_topic: "panasonic_heat_pump/s0/WatthourTotal/1"
+      unit_of_measurement: "kWh"
+      value_template: >-
+        {{ (value | int) / 1000}}
+      state_class: "measurement"
+
+    #S0 kWh Meter 2 - Assumed to measure the backup heater consumption
+    - name: Aquarea Metered Backup Heater Power Consumption
+      state_topic: "panasonic_heat_pump/s0/Watt/2"
+      unit_of_measurement: "W"
+      state_class: "measurement"
+
+    - name: Aquarea Metered Backup Heater Power Consumption Total
+      state_topic: "panasonic_heat_pump/s0/WatthourTotal/2"
+      unit_of_measurement: "kWh"
+      value_template: >-
+        {{ (value | int) / 1000}}
+      state_class: "measurement"
+
   # switch #
   ##########
   switch:


### PR DESCRIPTION
Commit https://github.com/Egyras/HeishaMon/commit/32d3bc53a96ac1845dd29b8ea9f043edff41208a removed the S0 readings from the Home Assistant template. However, some users prefer the S0 readings over the heat pump reported readings as they're more accurate. Bring back the S0 readings into the Home Assistant template as commented out examples.