### PR TITLE
pin library dependencies and replace OneWire with OneWireNg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,8 @@ jobs:
           arduino-cli core install esp32:esp32@3.0.7
 
       - name: Install dependencies
-        run:  arduino-cli lib install ringbuffer pubsubclient arduinojson dallastemperature onewire "Adafruit NeoPixel"
-
-      - name: Fix Onewire lib for ESP32-3.0.0
-        run: |
-          sed -i '/#include <driver\/rtc_io\.h>/a\
-          #include <soc\/gpio_struct\.h>' \
-          /home/runner/Arduino/libraries/OneWire/util/OneWire_direct_gpio.h
+        # Please keep LIBSUSED.md in sync with this list
+        run:  arduino-cli lib install RingBuffer@1.0.5 PubSubClient@2.8 ArduinoJson@7.4.2 DallasTemperature@4.0.5 OneWireNg@0.14.0 "Adafruit NeoPixel@1.15.1"
 
       - name: Compile Sketch for ESP8266
         run: cd HeishaMon && arduino-cli compile --output-dir . --fqbn=esp8266:esp8266:d1_mini:xtal=160,vt=flash,ssl=basic,mmu=3216,non32xfer=fast,eesz=4M2M,ip=lm2f,dbg=Disabled,lvl=None____,wipe=none,baud=921600 --warnings=none --verbose HeishaMon.ino

--- a/LIBSUSED.md
+++ b/LIBSUSED.md
@@ -9,7 +9,9 @@ Only actual code in build action is relevant!
 
 | lib | version | download |
 | ---- | ---- | ---- |
-|pubsubclient by nick o'leary | 2.8.0 | https://github.com/knolleary/pubsubclient/releases/tag/v2.8 |
-|arduinojson by benoit blanchon | 6.19.4 | https://github.com/bblanchon/ArduinoJson/releases/tag/v6.19.4 |
-|dallastemperature | 3.9.0 | https://github.com/milesburton/Arduino-Temperature-Control-Library/releases/tag/3.9.0 |
-|onewire | 2.3.5 | https://www.pjrc.com/teensy/td_libs_OneWire.html |
+|PubSubClient by nick o'leary | 2.8 | https://github.com/knolleary/pubsubclient/releases/tag/v2.8 |
+|ArduinoJson by benoit blanchon | 7.4.2 | https://github.com/bblanchon/ArduinoJson/releases/tag/v7.4.2 |
+|DallasTemperature | 4.0.5 | https://github.com/milesburton/Arduino-Temperature-Control-Library/releases/tag/v4.0.5 |
+|OneWireNg | 0.14.0 | https://github.com/pstolarz/OneWireNg/releases/tag/0.14.0 |
+|RingBuffer | 1.0.5 | https://github.com/Locoduino/RingBuffer/releases/tag/1.0.5 |
+|Adafruit NeoPixel | 1.15.1 | https://github.com/adafruit/Adafruit_NeoPixel/releases/tag/1.15.1 |


### PR DESCRIPTION
* Pin dependencies to avoid problems caused by updated libraries
* Replace problematic OneWire library with OneWireNg

Fixes #712 