### PR TITLE
Add Heater On Outdoor Temp SET command

### DIFF
--- a/HeishaMon/commands.cpp
+++ b/HeishaMon/commands.cpp
@@ -1035,6 +1035,26 @@ unsigned int set_room_heater_state(char *msg, unsigned char *cmd, char *log_msg)
   return sizeof(panasonicSendQuery);
 }
 
+unsigned int set_heater_on_outdoor_temp(char *msg, unsigned char *cmd, char *log_msg) {
+
+  String stringValue(msg);
+
+  byte byteValue = stringValue.toInt() + 128;
+
+  {
+    char tmp[256] = { 0 };
+    snprintf_P(tmp, 255, PSTR("set heater on outdoor temp to %d"), byteValue - 128 );
+    memcpy(log_msg, tmp, sizeof(tmp));
+  }
+
+  {
+    memcpy_P(cmd, panasonicSendQuery, sizeof(panasonicSendQuery));
+    cmd[85] = byteValue;
+  }
+
+  return sizeof(panasonicSendQuery);
+}
+
 unsigned int set_external_compressor_control(char *msg, unsigned char *cmd, char *log_msg){
   const byte off_state=64;
   const byte address=23;

--- a/HeishaMon/commands.h
+++ b/HeishaMon/commands.h
@@ -73,7 +73,7 @@ unsigned int set_pump_flowrate_mode(char *msg, unsigned char *cmd, char *log_msg
 unsigned int set_dhw_sensor_selection(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_dhw_heater_state(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_room_heater_state(char *msg, unsigned char *cmd, char *log_msg);
-
+unsigned int set_heater_on_outdoor_temp(char *msg, unsigned char *cmd, char *log_msg);
 
 //optional pcb commands
 unsigned int set_heat_cool_mode(char *msg, char *log_msg);
@@ -168,6 +168,7 @@ const cmdStruct commands[] PROGMEM = {
   { "SetDHWSensorSelection", set_dhw_sensor_selection },
   { "SetDHWHeaterState", set_dhw_heater_state },
   { "SetRoomHeaterState", set_room_heater_state },
+  { "SetHeaterOnOutdoorTemp", set_heater_on_outdoor_temp },
 };
 
 struct optCmdStruct{

--- a/MQTT-Topics.md
+++ b/MQTT-Topics.md
@@ -234,6 +234,8 @@ SET42 | SetPumpFlowrateMode | Set Pump Flowrate Mode | 0=deltaT, 1=max. duty
 SET43 | SetDHWSensorSelection | Set DHW tank sensor selection (K/L series All-In-One only) | 0=Top, 1=Center
 SET44 | SetDHWHeaterState | Allow DHW backup/booster heater | 0=blocked, 1=free
 SET45 | SetRoomHeaterState | Allow Room backup/booster heater | 0=blocked, 1=free
+SET46 | SetHeaterOnOutdoorTemp | Outdoor temperature for heater ON | -15 to 20
+
 
 *If you operate your heatpump in water mode with direct temperature setup: topics ending xxxRequestTemperature will set the absolute target temperature.*
 


### PR DESCRIPTION
### Summary
Adds a new MQTT/REST command SetHeaterOnOutdoorTemp so the “heater on outdoor temperature” threshold (TOP78 / main/Heater_On_Outdoor_Temp, documented range -15…20 °C) can be written from HeishaMon, not only read.
### Implementation
- New handler set_heater_on_outdoor_temp() in commands.cpp: parses the requested temperature, encodes it as value + 128 (same pattern as other temperature SET commands), and writes it to cmd[85] of the Panasonic send frame.
- Registers the command as SetHeaterOnOutdoorTemp in commands.h.
### Documentation
- MQTT-Topics.md: adds SET46 for SetHeaterOnOutdoorTemp.