### PR TITLE
Fix optional PCB commands in rules not taking effect on ESP32

### DIFF
--- a/HeishaMon/rules.cpp
+++ b/HeishaMon/rules.cpp
@@ -32,6 +32,9 @@
 #define OPTDATASIZE 20
 
 bool send_command(byte* command, int length);
+#ifdef ESP32
+extern QueueHandle_t pcbQueue;
+#endif
 
 extern int dallasDevicecount;
 extern dallasDataStruct *actDallasData;
@@ -690,6 +693,9 @@ static int8_t vm_value_set(struct rules_t *obj) {
           if(stricmp((char *)&key[1], tmp.name) == 0) {
             uint16_t len = tmp.func(payload, log_msg);
             log_message(log_msg);
+#ifdef ESP32
+            xQueueOverwrite(pcbQueue, optionalPCBQuery);
+#endif
             break;
           }
         }


### PR DESCRIPTION
On ESP32 the periodic optional PCB send runs in a FreeRTOS task that reads exclusively from pcbQueue via xQueuePeek. When a rule executed an optional PCB command (e.g. @SetZ2WaterTemp = 45), set_xxx_temp() correctly updated optionalPCBQuery but never wrote the new value to pcbQueue, so the task kept sending stale data indefinitely.

The MQTT path (send_heatpump_command) already called xQueueOverwrite after invoking the command function. Apply the same fix in vm_value_set so rules have the same behaviour.

On ESP8266 the periodic send reads optionalPCBQuery directly, so no change in behaviour there.