### PR TITLE
Update translated READMEs to match English README

### DIFF
--- a/README_DE.md
+++ b/README_DE.md
@@ -1,90 +1,451 @@
 [![Join us on Slack chat room](https://img.shields.io/badge/Slack-Join%20the%20chat%20room-orange)](https://join.slack.com/t/panasonic-wemos/shared_invite/enQtODg2MDY0NjE1OTI3LTgzYjkwMzIwNTAwZTMyYzgwNDQ1Y2QxYjkwODg3NjMyN2MyM2ViMDM3Yjc3OGE3MGRiY2FkYzI4MzZiZDVkNGE)
+[![Build binary](https://github.com/the78mole/HeishaMon/actions/workflows/main.yml/badge.svg)](https://github.com/the78mole/HeishaMon/actions/workflows/main.yml)
 
-# Panasonic H Series Aquarea air-water Wärmepumpen Protokoll
+
+# Panasonic H, J, K & L Series Aquarea Luft-Wasser-Wärmepumpen Protokoll
+
+Dieses Projekt ermöglicht es, Informationen von der Panasonic Aquarea Wärmepumpe auszulesen und die Daten entweder an einen MQTT-Server zu senden oder als JSON-Format über HTTP bereitzustellen.
+
+Die englische Originaldokumentation findest du unter [README.md](README.md). \
+Een nederlandse vertaling [README_NL.md](README_NL.md) vind je hier. \
+Suomen kielellä [README_FI.md](README_FI.md) luettavissa täällä.
 
 *Hilfe bei der Übersetzung in weitere Sprachen ist willkommen.*
 
-# Aktuelle Version
-Die aktuelle Version findest du hier: [README.md](README.md)
+# Aktuelle Versionen
+Die aktuelle Version findest du [hier](https://github.com/Egyras/HeishaMon/releases). Das für ESP8266 kompilierte Binary kann auf einem Wemos D1 mini, auf dem HeishaMon-PCB und grundsätzlich auf jedem ESP8266-basierten Board installiert werden, das mit den Wemos-Build-Einstellungen kompatibel ist (mindestens 4 MB Flash). Du kannst den Code auch selbst herunterladen und kompilieren (siehe erforderliche Bibliotheken unten). Das ESP32-S3-Binary ist für die neuere, große Version des Heishamon.
 
-# Nutzung der aktuellen Software
-Die aktuelle Arduino Software liest die Daten der CN-CNT Schnittstelle der Panasonic Aquarea H-Series Geräte. \
-Beim Build des Images musst du darauf achten, dass du die Optionen für die Nutzung des Dateisystems auf dem ESP8266 für das Flashen in der IDE auswählst.
 
-Nach dem ersten Start wird ein offener WiFi-Hotspot angeboten. Verbinde dich mit diesem Hotspot und konfiguriere dein eigenes Netzwerk sowie die Daten (IP, Login) deines MQTT-Servers. \
-Wenn du dein Board auf die Werkseinstellungen zurücksetzen möchtest, drücke bitte innerhalb von 0,1 Sekunden den Reset-Taster zweimal. Dabei wird das lokale Dateisystem formatiert und die Konfiguration für das WiFi-Netz gelöscht. Danach startet das Gerät neu und du kannst es wie nach dem ersten Start über den offenen Hotspot neu konfigurieren. \
-Nach der Konfiguration und dem Neustart beginnt die Kommunikation mit deiner Wärmepumpe. GPIO13/GPIO15 werden für die serielle Verbindung benutzt, die USB-Schnittstelle bleibt frei. \
-Serial 1 (GPIO2) ist ein serieller Port und kann genutzt werden, um Debug-Meldungen auszulesen. (GND und TX vom Board)
+# Nutzung der Software
+HeishaMon ist in der Lage, mit der Panasonic Aquarea H, J, K und L-Serie zu kommunizieren. [Vom Benutzer bestätigte Wärmepumpentypen findest du hier](HeatPumpType.md) \
+Wenn du das Image selbst kompilieren möchtest, stelle sicher, dass du die genannten Bibliotheken und die Unterstützung für ein Dateisystem auf dem ESP8266 verwendest. Wähle dazu die korrekte Flash-Option in der Arduino IDE.
 
-Alle von der Wärmepumpe empfangenen Daten werden an MQTT-Topics gesendet. Die Auflistung aller verwendeten Topics findest du weiter unten. Zusätzlich werden in dem Topic 'panasonic_heat_pump/log' Logging-Daten und ein Hexdump der empfangenen Daten bereitgestellt. Diese Funktion kann auf dem Webportal von HeishaMon aktiviert werden.
+Beim ersten Start ohne konfiguriertes WLAN wird ein offener WLAN-Hotspot sichtbar, der es dir ermöglicht, dein WLAN-Netzwerk und deinen MQTT-Server zu konfigurieren. Die Konfigurationsseite ist unter http://192.168.4.1 erreichbar. \
 
-Du kannst darüber hinaus an GPIO4 1-Wire-Temperatursensoren anschließen. Die Messwerte der Temperatursensoren werden an die Topics 'panasonic_heat_pump/1wire/sensorid' gesendet.
+Nach der Konfiguration und dem Neustart kann das Image die Wärmepumpe auslesen und mit ihr kommunizieren. Die GPIO13/GPIO15-Verbindung wird für die Kommunikation genutzt, sodass du deinen Computer/Uploader weiterhin angeschlossen lassen kannst. \
+Serial 1 (GPIO2) kann für eine weitere serielle Verbindung (nur GND und TX vom Board) verwendet werden, um Debug-Daten auszulesen.
 
-Ein Firmware-Update ist sehr einfach über das Firmware-Menü mit deinem Browser möglich. Nach der Anmeldung mit dem Benutzernamen 'admin' und dem von dir beim ersten Setup vergebenen Passwort kannst du die aktuelle Firmware-Datei auf das Gerät laden.
+Alle empfangenen Daten werden an verschiedene MQTT-Topics gesendet (siehe unten für Topic-Beschreibungen). Es gibt auch ein MQTT-Topic 'panasonic_heat_pump/log', das Debug-Logging und einen Hexdump der empfangenen Pakete bereitstellt (wenn im Webportal aktiviert).
 
-Alle Daten kannst du auch unter http://heishamon.local/json als JSON-Datei abrufen. Sollte bei dir mDNS nicht funktionieren, ersetze bitte heishamon.local durch die IP deines Gerätes.
+Du kannst ein 1-Wire-Netzwerk an GPIO4 anschließen, das in separaten MQTT-Topics (panasonic_heat_pump/1wire/sensorid) berichtet.
 
-Im Bereich 'Integrations' findest du Beispiele zur Integration von HeishaMon in dein Hausautomatisierungssystem.
+Die Software ist außerdem in der Lage, Watt an einem S0-Port von zwei kWh-Zählern zu messen. Du musst nur GPIO12 und GND an den S0-Anschluss eines kWh-Zählers verbinden. Wenn du einen zweiten kWh-Zähler benötigst, verwende GPIO14 und GND. Die Werte werden über das MQTT-Topic panasonic_heat_pump/s0/Watt/1 und panasonic_heat_pump/s0/Watt/2 sowie in der JSON-Ausgabe gemeldet. Du kannst 'Watt' im vorherigen Topic durch 'Watthour' ersetzen, um den Verbrauchszähler in Wattstunden (pro MQTT-Nachricht) zu erhalten, oder durch 'WatthourTotal', um den Gesamtverbrauch in Wattstunden zu erhalten. Um den WatthourTotal mit deinem kWh-Zähler zu synchronisieren, veröffentliche den korrekten Wert per MQTT an das Topic panasonic_heat_pump/s0/WatthourTotal/1 oder panasonic_heat_pump/s0/WatthourTotal/2 mit der 'retain'-Option, während Heishamon neu startet.
 
-# Weitere Information
-Hier findest du technische Informationen zum Projekt, um dir Kabel und Platine selbst anzufertigen.
+Das Firmware-Update ist so einfach wie das Aufrufen des Firmware-Menüs und nach der Authentifizierung mit dem Benutzernamen 'admin' und dem Passwort 'heisha' (oder einem anderen beim Setup angegebenen Passwort) das Hochladen der Binary.
+
+Eine JSON-Ausgabe aller empfangenen Daten (Wärmepumpe und 1-Wire) ist unter der URL http://heishamon.local/json verfügbar (ersetze heishamon.local durch die IP-Adresse deines Heishamon-Geräts, wenn MDNS nicht funktioniert).
+
+Im Ordner 'integrations' findest du Beispiele, wie du deine Automatisierungsplattform mit dem HeishaMon verbinden kannst.
+
+# Regeln-Funktionalität
+Die Regeln-Funktionalität ermöglicht es dir, die Wärmepumpe direkt vom HeishaMon aus zu steuern. Das macht es viel zuverlässiger als die Steuerung über externe Hausautomatisierung über WLAN. Wenn ein neues Regelwerk veröffentlicht wird, wird es sofort validiert und bei Gültigkeit übernommen. Wenn ein neues Regelwerk ungültig ist, wird es ignoriert und das alte Regelwerk wieder geladen. Du kannst die Konsole auf Rückmeldungen überprüfen. Falls ein neues gültiges Regelwerk den HeishaMon zum Absturz bringt, wird es beim nächsten Neustart automatisch deaktiviert, sodass du Änderungen vornehmen kannst. Dies verhindert eine Boot-Schleife des HeishaMon.
+
+Die im Regelwerk verwendeten Techniken ermöglichen die Arbeit mit sehr großen Regelwerken, aber Best Practice ist es, sie unter 10.000 Bytes zu halten.
+
+Beachte, dass das Senden von Befehlen an die Wärmepumpe asynchron erfolgt. Befehle, die zu Beginn deiner Syntax an die Wärmepumpe gesendet werden, spiegeln sich nicht sofort in den Werten der Wärmepumpe wider. Daher sollten Wärmepumpen-Werte direkt von der Wärmepumpe gelesen werden, nicht aus selbst gespeicherten Werten.
+
+## Syntax
+Zwei allgemeine Regeln: Leerzeichen sind obligatorisch und Semikolons werden als Zeilenende-Zeichen verwendet.
+
+### Variablen
+Das Regelwerk verwendet die folgende Variablenstruktur:
+
+- `#`: Globale Variablen
+Diese Variablen sind im gesamten Regelwerk zugänglich, müssen aber innerhalb eines Regelblocks definiert werden. Verwende keine globalen Variablen für alle deine Variablen, da sie dauerhaft Speicher belegen.
+
+- `$`: Lokale Variablen
+Diese Variablen leben innerhalb eines Regelblocks. Wenn ein Regelblock endet, werden diese Variablen bereinigt und der verwendete Speicher freigegeben.
+
+- `@`: Wärmepumpen-Parameter
+Diese sind dieselben wie in der Dokumentationsseite "Manage Topics" und auf der HeishaMon-Startseite aufgeführt. Das Regelwerk folgt auch der R/W-Logik, die über MQTT und REST API verwendet wird. Das bedeutet, dass sich die Lese-Topics von den Schreib-Topics unterscheiden. So erfolgt das Lesen des Wärmepumpenstatus über `@Heatpump_State`, das Ändern des Status über `@SetHeatpump`.
+
+- `%`: Datums- und Zeit-Variablen
+Diese können für datum- und zeitbasierte Regeln verwendet werden. Derzeit werden `%hour` (0-23), `%minute` (0-59), `%month` (1-12) und `day` (1-7) unterstützt. Alle sind einfache Integer. Eine ordnungsgemäße NTP-Konfiguration ist erforderlich, um das korrekte Systemdatum und die Systemzeit auf dem HeishaMon zu setzen.
+
+- `?`: Thermostat-Parameter
+Diese Variablen spiegeln Parameter wider, die vom angeschlossenen Thermostat gelesen werden, wenn die OpenTherm-Funktionalität verwendet wird. Die Namen sind für Lesen und Schreiben identisch, aber nicht alle Werte unterstützen Lesen und/oder Schreiben. Der OpenTherm-Tab listet dies auch auf.
+
+- `ds18b20#2800000000000000`: Dallas 1-Wire Temperaturwerte
+Verwende diese Variablen, um die Temperatur der angeschlossenen Sensoren zu lesen. Diese Werte sind natürlich schreibgeschützt. Die ID des Sensors sollte nach dem Hashtag stehen.
+
+- `s0#watt[hour[total]]_?`: Die S0-Werte für Port 1 und 2. Ersetze das Fragezeichen durch die Portnummer.
+Zum Beispiel s0#watt_1 für Watt von Port 1 und s0#watthourtotal_2 für gesamte Wattstunden von Port 2.
+
+
+Wenn eine Variable aufgerufen wird, aber noch keinen Wert hat, ist der Wert `NULL`.
+
+Variablen können vom Typ Boolean (`1` oder `0`), Float (`3.14`), Integer (`10`) und String sein. Strings werden mit einfachen oder doppelten Anführungszeichen definiert.
+
+### Ereignisse oder Funktionen
+Regeln werden in `event`- oder `function`-Blöcken geschrieben. Diese Blöcke werden ausgelöst, wenn etwas passiert: entweder ein neuer Wärmepumpen- oder Thermostatwert empfangen wurde oder ein Timer ausgelöst wurde. Oder sie können als einfache Funktionen verwendet werden.
+
+```
+on [event] then
+  [...]
+end
+
+on [name] then
+  [...]
+end
+```
+
+Ereignisse können Wärmepumpen- oder Thermostat-Parameter oder Timer sein:
+```
+on @Heatpump_State then
+  [...]
+end
+
+on ?setpoint then
+  [...]
+end
+
+on timer=1 then
+  [...]
+end
+```
+
+Wenn du Funktionen definierst, benennst du deinen Block einfach und kannst ihn von überall aus aufrufen:
+```
+on foobar then
+  [...]
+end
+
+on @Heatpump_State then
+  foobar();
+end
+```
+
+Funktionen können Parameter haben:
+```
+on foobar($a, $b, $c) then
+  [...]
+
+on @Heatpump_State then
+  foobar(1, 2, 3);
+end
+```
+
+Wenn du eine Funktion mit weniger Werten aufrufst, als die Funktion erwartet, haben alle anderen Parameter den Wert NULL.
+
+Es gibt eine spezielle Funktion, die beim Systemstart oder beim Speichern eines neuen Regelwerks aufgerufen wird:
+```
+on System#Boot then
+  [...]
+end
+```
+
+Diese spezielle Funktion kann verwendet werden, um deine globalen Variablen oder bestimmte Timer initial zu setzen.
+
+### Operatoren
+Reguläre Operatoren werden mit ihrer Standard-Assoziativität und -Präzedenz unterstützt. Dies ermöglicht auch die Verwendung regulärer Mathematik.
+- `&&`: Und
+- `||`: Oder
+- `==`: Gleich
+- `>=`: Größer oder gleich
+- `>`: Größer als
+- `<`: Kleiner als
+- `<=`: Kleiner oder gleich
+- `-`: Minus
+- `%`: Modulo
+- `*`: Multiplizieren
+- `/`: Dividieren
+- `+`: Plus
+- `^`: Potenz
+
+Klammern können verwendet werden, um Operatoren zu priorisieren, wie es in der regulären Mathematik der Fall wäre.
+
+### Funktionen
+- `coalesce`
+Gibt den ersten Wert zurück, der nicht `NULL` ist. Z.B. `$b = NULL; $a = coalesce($b, 1);` gibt 1 zurück. Diese Funktion akzeptiert eine unbegrenzte Anzahl von Argumenten.
+
+- `max`
+Gibt den maximalen Wert der Eingabeparameter zurück.
+
+- `min`
+Gibt den minimalen Wert der Eingabeparameter zurück.
+
+- `isset`
+Gibt den booleschen Wert true zurück, wenn die Eingabevariable noch `NULL` ist. In allen anderen Fällen gibt sie false zurück.
+
+- `round`
+Rundet den Eingabe-Float auf die nächste ganze Zahl.
+
+- `floor`
+Der größte ganzzahlige Wert, der kleiner oder gleich dem Eingabe-Float ist.
+
+- `ceil`
+Der kleinste ganzzahlige Wert, der größer oder gleich dem Eingabe-Float ist.
+
+- `setTimer`
+Setzt einen Timer, der in X Sekunden ausgelöst wird. Der erste Parameter ist die Timer-Nummer und der zweite Parameter die Anzahl der Sekunden bis zur Auslösung. Ein Timer wird nur einmal ausgelöst und muss für wiederkehrende Ereignisse neu gesetzt werden.
+
+- `print`
+Gibt einen Wert auf der Konsole aus.
+
+- `concat`
+Verbindet verschiedene Werte zu einem kombinierten String. Z.B.: `@SetCurves = concat('{zone1:{heat:{target:{high:', @Z1_Heat_Curve_Target_High_Temp, ',low:32}}}}');`
+
+- `gpio`
+Ermöglicht das Setzen oder Auslesen eines GPIO-Zustands. Wenn mit einem einzelnen Argument aufgerufen, wird der GPIO-Zustand zurückgegeben. Wenn mit zwei Argumenten aufgerufen, wird der Zustand eines GPIO gesetzt. Diese Funktion setzt nur digitale Pins, sodass der Zustand nur 0 oder 1 sein kann. Die beiden Relais auf dem großen Heishamon sind gpio21 und gpio47. Die benutzerkonfigurierbaren Extra-GPIOs (siehe unten) können ebenfalls über ihre Pin-Nummer angesprochen werden. Siehe das Beispiel zum Umschalten der Relais alle zwei Sekunden.
+
+```
+on System#Boot then
+   setTimer(10, 2);
+end
+
+on timer=10 then
+   setTimer(20, 2);
+   gpio(21,0);
+   gpio(47,1);
+end
+
+on timer=20 then
+   setTimer(10, 2);
+   gpio(21,1);
+   gpio(47,0);
+end
+```
+
+### Bedingungen
+Die einzigen unterstützten Bedingungen sind `if`, `else` und `elseif`:
+
+```
+if [Bedingung] then
+  [...]
+else
+  if [Bedingung] then
+    [...]
+  end
+end
+```
+
+```
+if [Bedingung] then
+  [...]
+elseif [Bedingung] then
+  if [Bedingung] then
+    [...]
+  else
+    [...]
+  end
+elseif [Bedingung] then
+  [...]
+else
+  [...]
+end
+```
+
+### Beispiele
+
+*WAR-Berechnung (Wettergeführte Regelung)*
+```
+on calcWar($Ta1, $Tb1, $Ta2, $Tb2) then
+	#maxTa = $Ta1;
+
+	if @Outside_Temp >= $Tb1 then
+		#maxTa = $Ta1;
+	elseif @Outside_Temp <= $Tb2 then
+		#maxTa = $Ta2;
+	else
+		#maxTa = $Ta1 + (($Tb1 - @Outside_Temp) * ($Ta2 - $Ta1) / ($Tb1 - $Tb2));
+	end
+end
+```
+
+*Thermostat-Sollwert*
+```
+on ?roomTemp then
+	calcWar(32, 14, 41, -4);
+
+	$margin = 0.25;
+
+	if ?roomTemp > (?roomTempSet + $margin) then
+		if @Heatpump_State == 1 then
+			@SetHeatpump = 0;
+		end
+	elseif ?roomTemp < (?roomTempSet - $margin) then
+		if @Heatpump_State == 0 then
+			@SetHeatpump = 1;
+		end
+	else
+		@SetZ1HeatRequestTemperature = round(#maxTa);
+	end
+end
+```
+
+# Werksreset
+Ein Werksreset kann über die Web-Oberfläche durchgeführt werden. Wenn die Web-Oberfläche nicht verfügbar ist, kann ein Doppel-Reset durchgeführt werden. Der Doppel-Reset sollte nicht zu schnell, aber auch nicht zu langsam ausgeführt werden. Normalerweise reicht eine halbe Sekunde zwischen den beiden Resets. Um anzuzeigen, dass der Doppel-Reset einen Werksreset durchgeführt hat, blinkt die blaue LED schnell (Du musst jetzt erneut Reset drücken, um den HeishaMon normal neu zu starten, wo ein WLAN-Hotspot sichtbar sein sollte).
+
+# Weitere Informationen
+Unten findest du einige technische Details zum Projekt. Wie du deine eigenen Kabel bauen kannst. Wie du deine eigene Platine bauen kannst usw.
 
 ## Verbindungsdetails:
-CN-CNT TTL UART 9600,8,E,1  \
-Pin-out (from top to bottom) \
+Die Kommunikation kann über einen der beiden Anschlüsse hergestellt werden: CN-CNT oder CN-NMODE. Wenn du eine vorhandene Panasonic CZ-TAW1 WiFi-Schnittstelle hast, die du durch HeishaMon ersetzen möchtest, musst du nur das Kabel aus dem CZ-TAW1 herausziehen und mit deinem HeishaMon-Gerät verbinden. Es ist jedoch nicht möglich, HeishaMon und das originale CZ-TAW1-Modul gleichzeitig als aktive Geräte zu verwenden. Es ist jedoch möglich, HeishaMon in den "Nur-Zuhören"-Modus zu versetzen, der die Koexistenz von HeishaMon und dem originalen CZ-TAW1-Modul ermöglicht. Der einzige Nachteil ist, dass HeishaMon keine Befehle senden und die optionale PCB-Option verwenden kann.
+
+Kommunikationsparameter: TTL 5V UART 9600,8,E,1  \
+ \
+CN-CNT Pin-Belegung (von oben nach unten) \
 1 - +5V (250mA)  \
-2 - 0-5V TX  \
-3 - 0-5 RX  \
+2 - 0-5V TX (von der Wärmepumpe) \
+3 - 0-5V RX (zur Wärmepumpe)\
 4 - +12V (250mA) \
-5 - GND
+5 - GND \
+ \
+CN-NMODE Pin-Belegung (von links nach rechts) \
+"Achtung! Wie auf der Platine aufgedruckt, ist der linke Pin Pin 4 und der rechte Pin ist Pin 1. Zähle nicht 1 bis 4 von links!  \
+4 - +5V (250mA)  \
+3 - 0-5V TX (von der Wärmepumpe) \
+2 - 0-5V RX (zur Wärmepumpe) \
+1 - GND
 
-## Stecker und Buchsen
-[RS-Online orders](Connectors_RSO.md)
+HeishaMon wird über das Kabel von Panasonic mit Strom versorgt (5V).
 
-[Conrad orders](Connectors_Conrad.md)
+## Verbindung über große Entfernung
+Es ist möglich, den HeishaMon über eine große Entfernung anzuschließen. Bis zu 5 Meter funktionieren mit normalem Kabel. Für größere Entfernungen ist eine TTL-zu-RS485-Konfiguration wie im Bild unten möglich. Dies erfordert jedoch eine externe 5V-Stromversorgung des HeishaMon (z.B. über ein USB-Kabel).
 
-Zusätzlich ist ein geschirmtes 4-adriges 24 AWG Kabel erforderlich. 
+![TTL-over-RS485 HeishaMon Verbindung über große Entfernung](optional-long-distance-heishamon.png)
 
 
-## Verbindung herstellen
-Aktuell sind mehrere Platinen in der Produktion (Beta). Wir empfehlen, noch unsere Tests abzuwarten.
-Es wird bald möglich sein, Platinen von den Projektmitgliedern zu erhalten. Die Layouts der Platinen und die Schaltpläne werden veröffentlicht.
-Hier findest du die Platinen, die im Moment getestet werden:
+## Wo du Steckverbinder bekommst
+[RS-Online Bestellungen](Connectors_RSO.md)
+
+[Conrad Bestellungen](Connectors_Conrad.md)
+
+Verwende ein abgeschirmtes 24 AWG 4-adriges Kabel.
+
+
+## Die HeishaMon-Hardware selbst
+Die zur Verbindung mit der Wärmepumpe benötigten PCBs wurden von Projektmitgliedern entworfen und sind unten aufgeführt. Der wichtigste Teil der Hardware ist eine Pegelumwandlung von 5V von Panasonic auf 3,3V des HeishaMon und eine GPIO13/GPIO15-Aktivierungsleitung nach dem Booten. \
 [PCB-Designs der Projektmitglieder](PCB_Designs.md) \
 [Bild Wemos D1 Beta](WEMOSD1.JPG) \
-[Bild ESP12-F](New_PCB.jpeg)
+[Bild ESP12-F](NewHeishamon.JPG)
 
+Um es einfach zu machen, kannst du eine fertige Platine von einigen Projektmitgliedern bestellen: \
+[Tindie-Shop](https://www.tindie.com/stores/thehognl/) von Igor Ybema (aka TheHogNL) aus den Niederlanden
 
+## Arduino-Image selbst bauen
+Boards: \
+esp8266 by esp8266 community version 3.0.2 [Arduino](https://github.com/esp8266/Arduino/releases/tag/3.0.2)
 
-## Build und Test des Arduino-Images
-Boards:
-esp8266 by esp8266 community version 2.6.3 [Arduino](https://github.com/esp8266/Arduino/releases/tag/2.6.3)
-
-[Von uns verwendete Bibliotheken](LIBSUSED.md)
+Alle [von uns verwendeten Bibliotheken](LIBSUSED.md) die zum Kompilieren notwendig sind.
 
 
 ## MQTT-Topics
 [Aktuelle Liste der dokumentierten MQTT-Topics findest du hier](MQTT-Topics.md)
 
-## DS18B20 1-Wire-Temperatursensor
-Die Software unterstützt DS18B20 1-Wire-Temperatursensoren. Der 1-Wire-Anschluss erfolgt an GPIO4 mit einem 4,7kΩ Pull-up-Widerstand. Die Daten werden alle 30 Sekunden an den MQTT-Server mit dem Topic panasonic_heat_pump/1wire/"sensor-hex-address" gesendet.
+## Kommunikationszuverlässigkeit
+Nachrichten von HeishaMon an die Wärmepumpe werden gelegentlich verworfen, besonders wenn mehrere Einstellungen in kurzer Zeit geändert werden. Es ist nicht möglich für HeishaMon, alle verworfenen Nachrichten zu wiederholen, daher sollten Benutzer ihre eigene Wiederholungslogik implementieren.
 
+Die empfohlene Wiederholungslogik ist folgende:
+1. Nachdem du eine Wärmepumpen-Einstellung über HeishaMon geändert hast, warte darauf, dass HeishaMon meldet, dass die Einstellung geändert wurde.
+2. Wenn die Einstellung nach 10 Sekunden nicht aktualisiert wurde, setze sie erneut.
 
-## Protokoll-Info-Packet:
-Um Daten von der Wärmepumpe zu erhalten, wird dieses "Magic"-Packet an die CN-CNT-Schnittstelle gesendet:
+Dies kann im HeishaMon selbst mit Regeln implementiert werden, wie in diesem Beispiel:
+```
+on StopExternalControl then
+  if @External_Control != 0 then
+    @SetExternalControl = 0;
+    settimer(9,10);
+  end
+end
 
-`71 6c 01 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 12`
+on timer=9 then
+  if @External_Control != 0 then
+    @SetExternalControl = 0;
+  end
+end
+```
 
+## EEPROM-Warnung
+Bis heute wissen wir nicht, wie die an die Wärmepumpe gesendeten Befehle in der Wärmepumpe selbst verarbeitet werden. Höchstwahrscheinlich werden viele Befehle in EEPROM gespeichert, um nach einem Stromausfall verfügbar zu sein, wie z.B. das Einstellen der Warmwassertemperatur. Ein EEPROM kann viele Schreibvorgänge verarbeiten, aber es gibt eine Grenze. Und wir kennen die Grenze auch nicht. Stelle also sicher, dass du die Wärmepumpe nicht mit zu vielen Befehlen überlastest. Jede Sekunde ist viel zu häufig. Ein paar pro Stunde und Einstellung sollte wahrscheinlich in Ordnung sein. Außerdem ist eine Wärmepumpe ein langsames Heiz-(Kühl-)Gerät, sodass so häufige Änderungen wahrscheinlich ohnehin keinen Sinn machen.
+
+## DS18b20 1-Wire-Unterstützung
+Die Software unterstützt auch das Auslesen von DS18B20 1-Wire-Temperatursensoren. Eine korrekte 1-Wire-Konfiguration (mit 4,7kOhm Pull-up-Widerstand) an GPIO4 wird alle konfigurierten Sekunden (mindestens 5) gelesen und an das Topic panasonic_heat_pump/1wire/"sensor-hex-adresse" gesendet. Auf den vorgefertigten Boards ist dieser 4,7kOhm-Widerstand bereits installiert.
+
+## Relaissteuerung auf der großen Platine
+Der neuere, große, Heishamon enthält zwei eingebaute Relais, die über MQTT-Befehle ein- und ausgeschaltet werden können. Die Relais können für jede Kontaktschaltung verwendet werden, auch 230V Netzspannung (max. 5A). Um das Relais zu steuern, sende einfach einen Wert von 1 oder 0 an das MQTT-Topic "panasonic_heat_pump/gpio/relay/one" für Relais eins oder "panasonic_heat_pump/gpio/relay/two" für Relais zwei.
+
+## Benutzerkonfigurierbare Extra-GPIOs
+Zusätzlich zu den festen Relais-Pins stellt HeishaMon eine Anzahl benutzerkonfigurierbarer GPIO-Pins bereit, die jeweils unabhängig über das Einstellungs-Webmenü auf Eingang (Pull-up), Eingang oder Ausgang gesetzt werden können.
+
+**Verfügbare Pins je Plattform:**
+- **ESP8266:** 3 Extra-GPIOs (Pins 1, 3, 16)
+- **ESP32:** 5 Extra-GPIOs (Pins 33–37); Relais-Pins 21 und 47 bleiben fest
+
+Der Modus für jeden Pin wird in den Einstellungen gespeichert und beim Booten sowie beim Speichern von Einstellungen angewendet.
+
+**Steuerung von Ausgangs-GPIOs über MQTT:**
+Sende `1`, `0`, `on`, `off`, `true` oder `false` an:
+```
+panasonic_heat_pump/gpio/extra/N
+```
+wobei `N` der 1-basierte Index des Extra-GPIO ist (z.B. `extra/1` für den ersten Extra-Pin).
+
+**GPIO-Zustände über MQTT lesen:**
+Eingangs- und Ausgangszustände werden automatisch bei Änderungen und beim ersten MQTT-Connect (retained) an dieselben Topics veröffentlicht.
+
+**HTTP API:**
+Alle Extra-GPIO-Zustände können als JSON über eine GET-Anfrage gelesen werden:
+```
+GET /gpio
+```
+Beispielantwort:
+```json
+[{"pin":33,"mode":2,"state":1},{"pin":34,"mode":0,"state":0}, ...]
+```
+wobei `mode` 0 = Eingang (Pull-up), 1 = Eingang, 2 = Ausgang bedeutet.
+
+Einen Ausgangspin per HTTP POST setzen:
+```
+POST /gpio?pin=N&value=1
+```
+
+**Extra-GPIOs in Regeln verwenden:**
+Die `gpio()`-Regelfunktion funktioniert mit den Extra-GPIO-Pins über ihre physische Pin-Nummer, genauso wie die Relais-Pins.
+
+## OpenTherm-Unterstützung
+Wenn deine Heishamon-Platine OpenTherm unterstützt, kann die Software auch verwendet werden, um OpenTherm-Informationen von einem kompatiblen Thermostat über MQTT oder JSON an deine Hausautomatisierung zu übertragen. Wenn du die OpenTherm-Unterstützung in den Einstellungen aktivierst, erscheint ein neuer Tab auf der Webseite mit OpenTherm-Werten. Einige sind vom Typ R(ead) und einige vom Typ W(rite), manche sind beides. Read bedeutet, dass der Thermostat diese Information vom Heishamon lesen kann. Du stellst diese Information über MQTT (oder per Regeln) bereit, indem du diesen Wert im MQTT-Topic 'opentherm/read' aktualisierst. Die Write-Werte sind Informationen vom Thermostat, wie 'roomTemp'. Diese sind im MQTT-Topic 'opentherm/write' verfügbar.
+
+Die verfügbaren OpenTherm-Variablen sind:
+### WRITE-Werte
+- chEnable: Boolean, ob Zentralheizung aktiviert werden soll
+- dhwEnable: Boolean, ob Warmwasserheizung aktiviert werden soll
+- coolingEnable: Boolean, ob Kühlung aktiviert werden soll
+- roomTemp: Float-Wert der gemessenen Raumtemperatur durch den Thermostat
+- roomTempSet: Float-Wert des angeforderten Raumtemperatur-Sollwerts am Thermostat
+- chSetpoint: Float-Wert des berechneten Wasser-Sollwerts durch den Thermostat
+- maxRelativeModulation: Modulationsmenge (0-100%), die die Wärmepumpe verwenden darf
+- coolingControl: Kühlmenge (0-100%), die der Thermostat von der Wärmepumpe anfordert
+### READ AND WRITE-Werte
+- dhwSetpoint: Float-Wert des aktuellen DHW-Sollwerts
+- maxTSet: Float-Wert, der den maximalen Wasser-Sollwert definiert
+### READ-Werte
+- chPressure: Float-Wert des gemessenen Wasserdrucks
+- outsideTemp: Float-Wert der gemessenen Außentemperatur
+- inletTemp: Float-Wert der gemessenen Wassereintrittstemperatur
+- outletTemp: Float-Wert der gemessenen Wasseraustrittstemperatur
+- dhwTemp: Float-Wert der gemessenen Warmwassertemperatur
+- relativeModulation: Aktuelle Modulationsmenge (0-100%)
+- flameState: Boolean, ob die Zentralheizung Wärme liefert
+- chState: Boolean, ob die Wärmepumpe im Raum-/Zentralheizungsmodus ist
+- dhwState: Boolean, ob die Wärmepumpe im Warmwassermodus ist
+- coolingState: Boolean, ob die Wärmepumpe im Kühlmodus ist
+- dhwSetUppBound: Integer (0-127), maximale DHW-Temperatur. Standard: 75
+- dhwSetLowBound: Integer (0-127), minimale DHW-Temperatur. Standard: 40
+- chSetUppBound: Integer (0-127), maximale CH-Wassertemperatur. Standard: 65
+- chSetLowBound: Integer (0-127), minimale CH-Wassertemperatur. Standard: 20
 
 ## Protokoll-Byte-Decrypt-Info:
-[Current list of documented bytes decrypted can be found here](ProtocolByteDecrypt.md)
+[Aktuelle Liste der dokumentierten dekodierten Bytes findest du hier](ProtocolByteDecrypt.md)
 
+## MQTT TLS-Unterstützung:
+TLS-Unterstützung für MQTT ist derzeit nur für die ESP32-Version implementiert. TLS ist standardmäßig deaktiviert und kann in den Einstellungen aktiviert werden. Stelle beim Aktivieren sicher, dass dein MQTT-Broker sichere Verbindungen von Heishamon akzeptiert, einschließlich der Einrichtung eines PEM CA-Zertifikats (z.B. selbstsigniert). Lade eine Textdatei (plain text mit Suffix pem, z.B. "CA.pem") des Zertifikats auf Heishamon im Einstellungsbildschirm hoch. Nach dem Hochladen des Zertifikats aktiviere die TLS-Unterstützung und wechsle (in normalen Setups) den MQTT-Port auf 8883. !!Es wird keinen Support für TLS-Probleme geben!! Google kann dir bei Problemen helfen.
 
-## Beispiele für Open-Source-Automatisierungssysteme
+## Integrationsbeispiele für Open-Source-Automatisierungssysteme
 [Openhab2](Integrations/Openhab2)
 
-[Home Assistant](https://github.com/Egyras/HeishaMon/tree/master/Integrations/Home%20Assistant)
+[Home Assistant](Integrations/Home%20Assistant)
 
-[ioBroker-Anleitung](Integrations/ioBroker_manual)
+[IOBroker-Anleitung](Integrations/ioBroker_manual)
 
 [Domoticz](Integrations/Domoticz)

--- a/README_FI.md
+++ b/README_FI.md
@@ -1,112 +1,451 @@
 [![Join us on Slack chat room](https://img.shields.io/badge/Slack-Join%20the%20chat%20room-orange)](https://join.slack.com/t/panasonic-wemos/shared_invite/enQtODg2MDY0NjE1OTI3LTgzYjkwMzIwNTAwZTMyYzgwNDQ1Y2QxYjkwODg3NjMyN2MyM2ViMDM3Yjc3OGE3MGRiY2FkYzI4MzZiZDVkNGE)
+[![Build binary](https://github.com/the78mole/HeishaMon/actions/workflows/main.yml/badge.svg)](https://github.com/the78mole/HeishaMon/actions/workflows/main.yml)
 
 
 # Panasonic Aquarea H-, J-, K- ja L-sarjan vesi-ilmalämpöpumpun protokollaa lukeva IoT-laite
 
-Tämä ESP8266-projekti mahdollistaa Panasonic Aquarea vesi-ilmalämpöpumppujen toimittamien tietojen raportoimisen MQTT-palvelimelle. Se tarjoaa myös JSON-muotoisen tiedon, jota voit pollata, jos et halua käyttää MQTT:tä. Myös ESP32 on tuettu.
+Tämä projekti mahdollistaa Panasonic Aquarea vesi-ilmalämpöpumppujen toimittamien tietojen raportoimisen MQTT-palvelimelle tai JSON-muodossa HTTP:n kautta.
 
-Ajantasainen, englanninkielinen [README.md](README.md) löytyy täältä.
+Ajantasainen, englanninkielinen [README.md](README.md) löytyy täältä. \
+Eine deutschsprachige [README_DE.md](README_DE.md) findest du hier. \
+Een nederlandse vertaling [README_NL.md](README_NL.md) vind je hier.
+
+*Apua käännöksiin muille kielille otetaan mielellään vastaan.*
 
 # Julkaistu versio
+Viimeisin julkaistu versio on saatavilla [täältä](https://github.com/Egyras/HeishaMon/releases). Se voidaan asentaa Wemos D1 minille, Heishamon PCB:lle tai luultavasti mille tahansa muulle ESP8266-pohjaiselle kehitysalustalle, joka on yhteensopiva Wemos-build-asetusten kanssa (vähintään 4 Mt flash-muistia). Voit myös ladata lähdekoodin ja kääntää omat binäärit (katso tarvittavat kirjastot alta). ESP32-S3-binääri on tarkoitettu uudelle, hieman suuremmalle Heishamon PCB:lle.
 
-Viimeisin julkaistu versio on saatavilla [täältä](https://github.com/Egyras/HeishaMon/releases) Se voidaan asentaa Wemos D1 minille, Heishamon PCB:lle tai luultavasti mille tahansa muulle ESP8266-pohjaiselle kehitysalustalle (ei takuita toimivuudesta, joidenkin Wemos-kopioiden kanssa ollut ongelmia). Voit myös ladata lähdekoodin ja kääntää omat binäärit (katso tarvittavat kirjastot alta). ESP32-S3 binääri on tarkoitettu uudelle, hieman suuremmalle Heishamon PCB:lle.
 
 # Käyttö
-
-Nykyinen Arduino-softa pystyy kommunikoimaan Panasonicin Aquarea H/J/K/L-sarjan vesi-ilmalämpöpumppujen kanssa. \
+Nykyinen Arduino-softa pystyy kommunikoimaan Panasonicin Aquarea H, J, K ja L-sarjan vesi-ilmalämpöpumppujen kanssa. [Käyttäjien vahvistamia lämpöpumppumalleja löytyy täältä](HeatPumpType.md) \
 Jos haluat kääntää softan itse, niin lataa kaikki tarvittavat kirjastot ja muista myös filesystem-tuki ESP8266:lle Arduino IDE:ssä.
 
-Kun ensimmäisen kerran kytket virrat laitteeseen, kytkeydy HeishaMonin tarjoamaan avoimeen WiFi-hotspotiin, jota käytetään ensimmäisen käynnistyksen yhteydessä asetusten tekemiseen. Asetussivu löytyy osoitteesta http://192.168.4.1 ja sieltä voit määrittää WiFi-verkon ja MQTT-palvelimen asetukset.
+Kun ensimmäisen kerran kytket virrat laitteeseen, kytkeydy HeishaMonin tarjoamaan avoimeen WiFi-hotspotiin, jota käytetään ensimmäisen käynnistyksen yhteydessä asetusten tekemiseen. Asetussivu löytyy osoitteesta http://192.168.4.1 ja sieltä voit määrittää WiFi-verkon ja MQTT-palvelimen asetukset. \
 
-Laitteen voi palauttaa tehdasasetuksille painamalla kaksi kertaa reset-nappia nopeasti. Silloin tiedostojärjestelmä tyhjennetään ja WiFi-asetukset palautetaan ennalleen ja voit taas liittyä avoimeen WiFi-verkkoon asetusten tekemistä varten.
-
-Kun olet tehnyt asetukset, laite käynnistyy uudestaan ja liittyy määrittelemääsi WiFi-verkkoon. Se alkaa kyselemään lämpöpumpulta tietoja säännöllisesti ja raportoi tiedot MQTT-palvelimelle. GPIO13/GPIO15-pinnejä käytetään tiedonsiirtoon ja voit pitää tietokoneesi kytkettynä USB-portissa, jos haluat lukea debug-tietoja tai päivittää firmwarea.
+Kun olet tehnyt asetukset, laite käynnistyy uudestaan ja liittyy määrittelemääsi WiFi-verkkoon. Se alkaa kyselemään lämpöpumpulta tietoja säännöllisesti ja raportoi tiedot MQTT-palvelimelle. GPIO13/GPIO15-pinnejä käytetään tiedonsiirtoon ja voit pitää tietokoneesi kytkettynä USB-portissa, jos haluat lukea debug-tietoja tai päivittää firmwarea. \
+Serial 1 (GPIO2) voidaan liittää toiseen sarjaväylään (vain GND ja TX laitteelta) debug-tietojen lukemiseen.
 
 Kaikki vastaanotettu tieto raportoidaan eri MQTT-aiheiden alle (katso koko lista alempaa). Web UI:n kautta voi myös kytkeä päälle lokituksen ja viestien hexadumppauksen, jolloin nämä tiedot raportoidaan aiheen 'panasonic_heat_pump/log' alle.
 
 Voit myös liittää 1-wire sensorin GPIO4-liitäntään ja sen arvo raporoidaan omassa MQTT-aiheessaan (panasonic_heat_pump/1wire/sensorid).
 
-HeishaMon voi myös lukea kahden kWh-mittarin S0-portista sähkönkulutusta. Kytke GPIO12 ja GND kWh-mittarin S0-liitäntään ja jos tarvitset vielä toisen liitännän käytä GPIO14:ta siihen. Kulutus raportoidaan MQTT-aiheiden 'panasonic_heat_pump/s0/Watt/1' ja 'panasonic_heat_pump/s0/Watt/2' alla sekä JSON-tulosteessa. Hetkellisen tehon sijasta näet kulutuksen (kWh), jos vaihdat topiciin 'Watt'in sijasta 'Watthour'.
+HeishaMon voi myös lukea kahden kWh-mittarin S0-portista sähkönkulutusta. Kytke GPIO12 ja GND kWh-mittarin S0-liitäntään ja jos tarvitset vielä toisen liitännän käytä GPIO14:ta siihen. Kulutus raportoidaan MQTT-aiheiden 'panasonic_heat_pump/s0/Watt/1' ja 'panasonic_heat_pump/s0/Watt/2' alla sekä JSON-tulosteessa. Hetkellisen tehon sijasta näet kulutuksen (kWh), jos vaihdat topiciin 'Watt'in sijasta 'Watthour', tai kokonaiskulutuksen 'WatthourTotal'-arvolla. WatthourTotal-arvon synkronoimiseksi kWh-mittarisi kanssa julkaise oikea arvo MQTT:llä topiciin panasonic_heat_pump/s0/WatthourTotal/1 tai panasonic_heat_pump/s0/WatthourTotal/2 'retain'-optiolla laitteen käynnistyksen aikana.
 
-Firmwaren voi päivittää laitteen konfigurointisivun kautta kirjautumalla tunnuksella 'admin' ja valitsemallasi salasanalla (oletus on heisha).
+Firmwaren voi päivittää laitteen konfigurointisivun kautta kirjautumalla tunnuksella 'admin' ja valitsemallasi salasanalla (oletus on 'heisha').
 
 JSON-muodossa lämpöpumpun tilan voi hakea osoitteesta http://heishamon.local/json (korvaa heishamon.local laitteesi IP-osoitteella, jos MDNS ei toimi verkossasi).
 
-'integrations' hakemistosta löydät esimerkkejä laitteen integroimisesta erilaisiin kotiautomaatiojärjestelmiin.
+'integrations'-hakemistosta löydät esimerkkejä laitteen integroimisesta erilaisiin kotiautomaatiojärjestelmiin.
+
+# Säännöt-toiminnallisuus
+Säännöt-toiminnallisuus mahdollistaa lämpöpumpun ohjaamisen suoraan HeishaMonista käsin. Tämä on paljon luotettavampaa kuin ulkoisen kotiautomaation käyttäminen WiFin yli. Kun uusi sääntöjoukko julkaistaan, se validoidaan välittömästi ja otetaan käyttöön jos se on kelvollinen. Jos uusi sääntöjoukko on virheellinen, se jätetään huomiotta ja vanha sääntöjoukko ladataan uudelleen. Voit tarkistaa konsolista palautteen tästä. Jos jokin kelvollinen sääntöjoukko kaataa HeishaMonin, se poistetaan automaattisesti käytöstä seuraavalla käynnistyksellä, jolloin voit tehdä muutoksia. Tämä estää HeishaMonia joutumasta käynnistyssilmukkaan.
+
+Sääntökirjastossa käytetyt tekniikat mahdollistavat erittäin suurten sääntöjoukkojen käytön, mutta parhaana käytäntönä on pitää ne alle 10 000 tavun koossa.
+
+Huomaa, että komentojen lähettäminen lämpöpumpulle tapahtuu asynkronisesti. Syntaksin alussa lämpöpumpulle lähetetyt komennot eivät heti näy lämpöpumpun arvoissa myöhemmin. Siksi lämpöpumpun arvot tulisi lukea suoraan lämpöpumpulta eikä itse tallentamistasi arvoista.
+
+## Syntaksi
+Kaksi yleistä sääntöä: välilyönnit ovat pakollisia ja puolipisteitä käytetään rivin lopun merkkinä.
+
+### Muuttujat
+Sääntöjoukko käyttää seuraavaa muuttujarakennetta:
+
+- `#`: Globaalit
+Näihin muuttujiin pääsee käsiksi koko sääntöjoukossa, mutta ne on määriteltävä sääntöblokin sisällä. Älä käytä globaaleja kaikkiin muuttujiisi, sillä ne käyttävät muistia jatkuvasti.
+
+- `$`: Lokaalit
+Nämä muuttujat elävät sääntöblokin sisällä. Kun sääntöblokki päättyy, nämä muuttujat siivotaan ja käytetty muisti vapautetaan.
+
+- `@`: Lämpöpumpun parametrit
+Nämä ovat samat kuin Manage Topics -dokumentaatiosivulla ja HeishaMonin etusivulla listatut. Sääntöjoukko noudattaa myös MQTT:n ja REST API:n kautta käytettävää R/W-logiikkaa. Tämä tarkoittaa, että lukuaihiot eroavat kirjoitusaihioista. Lämpöpumpun tilan lukeminen tapahtuu `@Heatpump_State`:lla, tilan muuttaminen `@SetHeatpump`:lla.
+
+- `%`: Päivämäärä- ja aikamuuttujat
+Näitä voidaan käyttää päivämäärä- ja aikapohjaisiin sääntöihin. Tällä hetkellä tuetaan `%hour` (0-23), `%minute` (0-59), `%month` (1-12) ja `day` (1-7). Kaikki ovat tavallisia kokonaislukuja. Oikea NTP-konfiguraatio tarvitaan oikean järjestelmäpäivämäärän ja -ajan asettamiseen HeishaMoniin.
+
+- `?`: Termostaattiparametrit
+Nämä muuttujat heijastavat parametreja, jotka luetaan yhdistetyltä termostaatilta OpenTherm-toiminnallisuutta käytettäessä. Nimet ovat samat lukemiseen ja kirjoittamiseen, mutta kaikki arvot eivät tue lukemista ja/tai kirjoittamista.
+
+- `ds18b20#2800000000000000`: Dallas 1-wire lämpötila-arvot
+Käytä näitä muuttujia kytkettyjen antureiden lämpötilan lukemiseen. Nämä arvot ovat tietenkin vain luku -muuttujia. Anturin ID tulee risuaidan jälkeen.
+
+- `s0#watt[hour[total]]_?`: S0-arvot porteille 1 ja 2. Korvaa kysymysmerkki porttinumerolla.
+Esimerkiksi s0#watt_1 portista 1 ja s0#watthourtotal_2 portista 2 kokonaistuntikulutukseksi.
+
+
+Kun muuttujaa kutsutaan mutta sillä ei vielä ole arvoa, arvo on `NULL`.
+
+Muuttujat voivat olla tyyppiä Boolean (`1` tai `0`), float (`3.14`), integer (`10`) tai string. Merkkijonot määritellään yksin- tai kaksinkertaisilla lainausmerkeillä.
+
+### Tapahtumat tai funktiot
+Säännöt kirjoitetaan `event`- tai `function`-lohkoihin. Nämä ovat lohkoja, jotka laukaistaan kun jotain tapahtuu; joko uusi lämpöpumppu- tai termostaattiarvo on vastaanotettu tai ajastin laukesi. Tai niitä voidaan käyttää tavallisina funktioina.
+
+```
+on [tapahtuma] then
+  [...]
+end
+
+on [nimi] then
+  [...]
+end
+```
+
+Tapahtumat voivat olla lämpöpumppu- tai termostaattiparametreja tai ajastimia:
+```
+on @Heatpump_State then
+  [...]
+end
+
+on ?setpoint then
+  [...]
+end
+
+on timer=1 then
+  [...]
+end
+```
+
+Funktioita määriteltäessä nimeät lohkosi ja voit kutsua sitä mistä tahansa:
+```
+on foobar then
+  [...]
+end
+
+on @Heatpump_State then
+  foobar();
+end
+```
+
+Funktioilla voi olla parametreja:
+```
+on foobar($a, $b, $c) then
+  [...]
+
+on @Heatpump_State then
+  foobar(1, 2, 3);
+end
+```
+
+Jos kutsut funktiota vähemmällä arvoilla kuin funktio odottaa, kaikilla muilla parametreilla on NULL-arvo.
+
+On yksi erityisfunktio, joka kutsutaan järjestelmän käynnistyksen yhteydessä tai kun uusi sääntöjoukko tallennetaan:
+```
+on System#Boot then
+  [...]
+end
+```
+
+Tätä erityisfunktiota voidaan käyttää globaalien tai tiettyjen ajastimien alustamiseen.
+
+### Operaattorit
+Tavallisia operaattoreita tuetaan standardisella assosiatiivisuudella ja prioriteetilla. Tämä mahdollistaa myös tavallisen matematiikan käytön.
+- `&&`: Ja
+- `||`: Tai
+- `==`: Yhtä suuri
+- `>=`: Suurempi tai yhtä suuri
+- `>`: Suurempi kuin
+- `<`: Pienempi kuin
+- `<=`: Pienempi tai yhtä suuri
+- `-`: Miinus
+- `%`: Modulo
+- `*`: Kertolasku
+- `/`: Jakolasku
+- `+`: Plus
+- `^`: Potenssi
+
+Sulkeita voidaan käyttää operaattorien priorisoimiseen kuten normaalissa matematiikassa.
+
+### Funktiot
+- `coalesce`
+Palauttaa ensimmäisen arvon, joka ei ole `NULL`. Esim. `$b = NULL; $a = coalesce($b, 1);` palauttaa 1. Tämä funktio hyväksyy rajattoman määrän argumentteja.
+
+- `max`
+Palauttaa syöteparametrien maksimiarvo.
+
+- `min`
+Palauttaa syöteparametrien minimiarvo.
+
+- `isset`
+Palauttaa boolean true, kun syötemuuttuja on vielä `NULL`, muissa tapauksissa false.
+
+- `round`
+Pyöristää syöte-floatin lähimpään kokonaislukuun.
+
+- `floor`
+Suurin kokonaislukuarvo, joka on pienempi tai yhtä suuri kuin syöte-float.
+
+- `ceil`
+Pienin kokonaislukuarvo, joka on suurempi tai yhtä suuri kuin syöte-float.
+
+- `setTimer`
+Asettaa ajastimen laukeamaan X sekunnin kuluttua. Ensimmäinen parametri on ajastimen numero ja toinen parametri sekuntien määrä ennen laukeamista. Ajastin laukeaa vain kerran ja se on asetettava uudelleen toistuvia tapahtumia varten.
+
+- `print`
+Tulostaa arvon konsoliin.
+
+- `concat`
+Yhdistää eri arvot yhdistetyksi merkkijonoksi. Esim.: `@SetCurves = concat('{zone1:{heat:{target:{high:', @Z1_Heat_Curve_Target_High_Temp, ',low:32}}}}');`
+
+- `gpio`
+Mahdollistaa GPIO-tilan asettamisen tai lukemisen. Kun kutsutaan yhdellä argumentilla, palautetaan GPIO-tila. Kun kutsutaan kahdella argumentilla, asetetaan GPIO:n tila. Tämä funktio asettaa vain digitaalisia pinnejä, joten tila voi olla vain 0 tai 1. Kaksi relettä suuressa heishamonissa ovat gpio21 ja gpio47. Käyttäjän konfiguroitavia ylimääräisiä GPIO:ita (katso alla) voidaan myös osoittaa niiden pinnumerolla. Katso esimerkki releiden vaihtamiseen kahden sekunnin välein.
+
+```
+on System#Boot then
+   setTimer(10, 2);
+end
+
+on timer=10 then
+   setTimer(20, 2);
+   gpio(21,0);
+   gpio(47,1);
+end
+
+on timer=20 then
+   setTimer(10, 2);
+   gpio(21,1);
+   gpio(47,0);
+end
+```
+
+### Ehdot
+Ainoa tuettu ehtolauseke on `if`, `else` ja `elseif`:
+
+```
+if [ehto] then
+  [...]
+else
+  if [ehto] then
+    [...]
+  end
+end
+```
+
+```
+if [ehto] then
+  [...]
+elseif [ehto] then
+  if [ehto] then
+    [...]
+  else
+    [...]
+  end
+elseif [ehto] then
+  [...]
+else
+  [...]
+end
+```
+
+### Esimerkkejä
+
+*WAR-laskenta (säätilaan perustuva säätö)*
+```
+on calcWar($Ta1, $Tb1, $Ta2, $Tb2) then
+	#maxTa = $Ta1;
+
+	if @Outside_Temp >= $Tb1 then
+		#maxTa = $Ta1;
+	elseif @Outside_Temp <= $Tb2 then
+		#maxTa = $Ta2;
+	else
+		#maxTa = $Ta1 + (($Tb1 - @Outside_Temp) * ($Ta2 - $Ta1) / ($Tb1 - $Tb2));
+	end
+end
+```
+
+*Termostaatin asetusarvo*
+```
+on ?roomTemp then
+	calcWar(32, 14, 41, -4);
+
+	$margin = 0.25;
+
+	if ?roomTemp > (?roomTempSet + $margin) then
+		if @Heatpump_State == 1 then
+			@SetHeatpump = 0;
+		end
+	elseif ?roomTemp < (?roomTempSet - $margin) then
+		if @Heatpump_State == 0 then
+			@SetHeatpump = 1;
+		end
+	else
+		@SetZ1HeatRequestTemperature = round(#maxTa);
+	end
+end
+```
+
+# Tehdasasetusten palauttaminen
+Tehdasasetukset voidaan palauttaa web-käyttöliittymän kautta, mutta jos web-käyttöliittymä ei ole käytettävissä, voit suorittaa kaksoisnollauksen. Kaksoisnollaus tulisi suorittaa ei liian nopeasti mutta ei liian hitaastikaan. Yleensä puoli sekuntia nollausten välillä toimii. Merkiksi siitä, että kaksoisnollaus suoritti tehdasasetusten palautuksen, sininen LED vilkkuu nopeasti (sinun täytyy nyt painaa nollausta uudelleen käynnistääksesi HeishaMonin normaalisti, jolloin WiFi-hotspot pitäisi näkyä).
 
 # Lisätietoa
-
 Alla vielä hieman teknisiä lisätietoja projektista, kuten esimerkiksi kaapelinrakennusohjeet ja apua piirilevyn suunnitteluun.
 
 ## Yhteys lämpöpumppuun
-
-Yhteys voidaan muodostaa CN-CNT tai CN-NMODE liitäntöjen kautta. Molempia ei voida käyttää samanaikaisesti. Huomaa, että jos sinulla on Panasonicin CZ-TAW1 WiFi-sovitin käytössäsi, voit vain kytkeä HeishaMon-laitteen sen sijasta käyttäen samaa kaapelia.
+Yhteys voidaan muodostaa CN-CNT tai CN-NMODE liitäntöjen kautta. Jos sinulla on Panasonicin CZ-TAW1 WiFi-sovitin käytössäsi, voit vain kytkeä HeishaMon-laitteen sen sijasta käyttäen samaa kaapelia. HeishaMonin ja alkuperäisen CZ-TAW1-moduulin samanaikainen käyttö aktiivisina laitteina ei kuitenkaan ole mahdollista. HeishaMon voidaan asettaa "Vain kuuntele" -tilaan, jolloin ne voivat toimia rinnakkain. Ainoa haittapuoli on, että HeishaMon ei voi lähettää komentoja eikä käyttää valinnaista PCB-optiota.
 
 Yhteysasetukset: TTL 5V UART 9600,8,E,1 \
 \
 CN-CNT Pin-out (ylhäältä alas) \
 1 - +5V (250mA)  \
-2 - 0-5V TX  \
-3 - 0-5V RX  \
+2 - 0-5V TX (lämpöpumpulta) \
+3 - 0-5V RX (lämpöpumpulle)\
 4 - +12V (250mA) \
 5 - GND \
  \
 CN-NMODE Pin-out (vasemmalta oikealle) \
-"Huom! Kuten piirilevyllä sanotaan, vasen pinni on numero 4 ja oikealla reunassa on pinni 1. \
+"Huom! Kuten piirilevyllä sanotaan, vasen pinni on numero 4 ja oikealla reunassa on pinni 1. Älä laske 1:stä 4:ään vasemmalta!  \
 4 - +5V (250mA)  \
-3 - 0-5V TX  \
-2 - 0-5V RX  \
+3 - 0-5V TX (lämpöpumpulta) \
+2 - 0-5V RX (lämpöpumpulle) \
 1 - GND
 
-Heishamon saa virtansa Aquarea-lämpöpumpulta, erillistä virtalähdettä ei tarvita.
+Heishamon saa virtansa Aquarea-lämpöpumpulta kaapelin kautta (5V virta), erillistä virtalähdettä ei tarvita.
 
-## Mistä ostaa liittimiä 
+## Pitkän matkan yhteys
+HeishaMonin voi kytkeä pitkän matkan päähän. Jopa 5 metriä toimii normaalilla kaapeloinnilla. Pidemmille matkoille TTL-RS485-konfiguraatio alla olevan kuvan mukaisesti on mahdollinen. Tämä vaatii kuitenkin HeishaMonin ulkoisen virransyötön 5V:llä (esimerkiksi USB-kaapelilla).
+
+![TTL-over-RS485 HeishaMon pitkän matkan yhteys](optional-long-distance-heishamon.png)
+
+
+## Mistä ostaa liittimiä
 [RS-Online orders](Connectors_RSO.md)
 
 [Conrad orders](Connectors_Conrad.md)
 
 Käytä 24 AWG suojattua 4-johtimista kaapelia.
 
-## Piirilevyn valmistaminen 
-The PCB's needed to connect to the heatpump are designed by project members and are listed below. \
-[PCD Designs from the project members](PCB_Designs.md) \
-[Picture Wemos D1 beta](WEMOSD1.JPG) \
-[Picture ESP12-F](NewHeishamon.JPG)
+
+## Piirilevyn valmistaminen
+Lämpöpumppuun kytkemiseen tarvittavat PCB:t on suunniteltu projektin jäsenten toimesta ja ne on lueteltu alla. Tärkein osa laitteistoa on tasomuunnos Panasonicin 5V:sta HeishaMonin 3,3V:iin sekä GPIO13/GPIO15-aktivointilinja käynnistyksen jälkeen. \
+[PCB-suunnitelmat projektin jäseniltä](PCB_Designs.md) \
+[Kuva Wemos D1 Beta](WEMOSD1.JPG) \
+[Kuva ESP12-F](NewHeishamon.JPG)
 
 Jos haluat päästä helpolla, voit myös ostaa valmiin piirilevyn tai kaapelin, joita projektin jäsenet ovat tehneet: \
-[Tindie shop](https://www.tindie.com/stores/thehognl/) - Igor Ybema (aka TheHogNL) Hollannissa
+[Tindie-kauppa](https://www.tindie.com/stores/thehognl/) - Igor Ybema (aka TheHogNL) Hollannissa
 
-
-## Arduino-imagen kääntäminen 
-boards: \
+## Arduino-imagen kääntäminen
+Boards: \
 esp8266 by esp8266 community version 3.0.2 [Arduino](https://github.com/esp8266/Arduino/releases/tag/3.0.2)
 
 [Käytetyt kirjastot](LIBSUSED.md)
 
 
-## MQTT-aiheet 
+## MQTT-aiheet
 [Lista tämän hetkisistä MQTT-aiheista](MQTT-Topics.md)
 
-## DS18b20 1-wire tuki
+## Viestintäluotettavuus
+HeishaMonilta lämpöpumpulle lähetetyt viestit saatetaan toisinaan hylätä, erityisesti jos useita asetuksia muutetaan lyhyessä ajassa. HeishaMonin ei ole mahdollista yrittää uudelleen kaikkia hylättyjä viestejä, joten käyttäjien tulisi toteuttaa oma uudelleenyrityslogiikkansa.
 
-Softa tukee myös DS18B20 1-wire lämpötilasensoreita. Kunnollinen 1-wire sensori (sis. 4.7 kOhm pull-up vastuksen) liitettynä GPIO4-liitäntään luetaan joka 30 sekunnin välein ja tieto palautetaan 'panasonic_heat_pump/1wire/"sensor-hex-address"' aiheessa.
- 
-## Protocol info -paketti:
-Saadaksesi tietoa pumpulta, täytyy sille lähettää "magic" paketti:
+Suositeltu uudelleenyrityslogiikka on seuraava:
+1. Lämpöpumpun asetuksen muuttamisen jälkeen HeishaMonin kautta, odota HeishaMonin raportoivan, että asetus on muuttunut.
+2. Jos asetus ei ole päivittynyt 10 sekunnin kuluttua, aseta se uudelleen.
 
-`71 6c 01 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 12`
+Tämä voidaan toteuttaa HeishaMonissa itsessään Sääntöjä käyttäen, kuten tässä esimerkissä:
+```
+on StopExternalControl then
+  if @External_Control != 0 then
+    @SetExternalControl = 0;
+    settimer(9,10);
+  end
+end
 
+on timer=9 then
+  if @External_Control != 0 then
+    @SetExternalControl = 0;
+  end
+end
+```
 
-## Viestin formaatti: 
-[Current list of documented bytes decrypted can be found here](ProtocolByteDecrypt.md)
+## EEPROM-varoitus
+Tähän päivään asti emme tiedä, miten lämpöpumpulle lähetetyt komennot käsitellään lämpöpumpussa itsessään. Todennäköisesti monet komennot kirjoitetaan EEPROM:iin tallennettavaksi sähkökatkon jälkeen, kuten käyttöveden lämpötilan asettaminen. EEPROM kestää monia kirjoitustapahtumia, mutta rajalla on raja. Emmekä tiedä rajaa myöskään. Varmista siis, ettet ylikuormita lämpöpumppua liian monilla komennoilla. Jokainen sekunti on liikaa. Muutama tunneissa, asetusta kohti, on todennäköisesti hyvä. Lämpöpumppu on kuitenkin hidas lämmitys-(jäähdytys-)laite, joten niin tiheät muutokset eivät todennäköisesti edes tuota mitään hyötyä.
 
+## DS18b20 1-wire-tuki
+Softa tukee myös DS18B20 1-wire lämpötilasensoreita. Kunnollinen 1-wire sensori (sis. 4,7 kOhm pull-up vastuksen) liitettynä GPIO4-liitäntään luetaan joka konfiguroiduin sekunnein (vähintään 5) ja tieto palautetaan 'panasonic_heat_pump/1wire/"sensor-hex-address"' aiheessa. Valmiissa piirilevyissä tämä 4,7 kOhm vastus on jo asennettu.
+
+## Suuren piirilevyn releohjaus
+Uudempi, suuri heishamon sisältää kaksi sisäänrakennettua relettä, joita voidaan kytkeä päälle ja pois MQTT-komennoilla. Releitä voidaan käyttää minkä tahansa kontaktikytkennän, jopa 230V verkkojännitteen (max 5A) kytkemiseen. Releen ohjaamiseksi lähetä arvo 1 tai 0 MQTT-aiheeseen "panasonic_heat_pump/gpio/relay/one" releelle yksi tai "panasonic_heat_pump/gpio/relay/two" releelle kaksi.
+
+## Käyttäjän konfiguroitavat ylimääräiset GPIO:t
+Kiinteiden relepinnien lisäksi HeishaMon tarjoaa joukon käyttäjän konfiguroitavia GPIO-pinnejä, jotka voidaan itsenäisesti asettaa Tulo (pull-up), Tulo tai Lähtö -tilaan asetusten web-valikon kautta.
+
+**Käytettävissä olevat pinnit alustasta riippuen:**
+- **ESP8266:** 3 ylimääräistä GPIO:ta (pinnit 1, 3, 16)
+- **ESP32:** 5 ylimääräistä GPIO:ta (pinnit 33–37); relepinnit 21 ja 47 pysyvät kiinteinä
+
+Jokaisen pinnin tila tallennetaan asetuksiin ja sovelletaan käynnistyksen yhteydessä ja asetusten tallentamisen yhteydessä.
+
+**Lähtö-GPIO:iden ohjaaminen MQTT:n kautta:**
+Lähetä `1`, `0`, `on`, `off`, `true` tai `false` aiheeseen:
+```
+panasonic_heat_pump/gpio/extra/N
+```
+jossa `N` on ylimääräisen GPIO:n 1-perusteinen indeksi (esim. `extra/1` ensimmäiselle ylimääräiselle pinnille).
+
+**GPIO-tilojen lukeminen MQTT:n kautta:**
+Tulo- ja lähtötilat julkaistaan automaattisesti samoihin aiheisiin muutoksen yhteydessä ja ensimmäisellä MQTT-yhteydellä (retained).
+
+**HTTP API:**
+Kaikki ylimääräiset GPIO-tilat voidaan lukea JSON-muodossa GET-pyynnöllä:
+```
+GET /gpio
+```
+Esimerkkivastaus:
+```json
+[{"pin":33,"mode":2,"state":1},{"pin":34,"mode":0,"state":0}, ...]
+```
+jossa `mode` on 0 = Tulo (pull-up), 1 = Tulo, 2 = Lähtö.
+
+Lähtöpinnin asettaminen HTTP POST:lla:
+```
+POST /gpio?pin=N&value=1
+```
+
+**Ylimääräisten GPIO:iden käyttö säännöissä:**
+`gpio()`-sääntöfunktio toimii ylimääräisten GPIO-pinnien kanssa niiden fyysisen pinnin numeron kautta, samoin kuin relepinnit.
+
+## OpenTherm-tuki
+Jos heishamon-piirilevysi tukee OpenThermia, ohjelmistoa voidaan käyttää myös OpenTherm-tietojen välittämiseen yhteensopivalta termostaatilta kotiautomaatiojärjestelmällesi MQTT:n tai JSON:n kautta. Jos otat OpenTherm-tuen käyttöön asetuksissa, verkkosivulle ilmestyy uusi välilehti. Siellä näet OpenTherm-arvot. Osa on tyyppiä R(ead) ja osa W(rite), ja osa on molempia. Read tarkoittaa, että termostaatti voi lukea tietoa heishamonilta. Toimitat tiedon MQTT:n kautta (tai säännöillä) päivittämällä tämän arvon MQTT-aiheessa 'opentherm/read'. Write-arvot ovat tietoa termostaatilta, kuten 'roomTemp'. Nämä ovat saatavilla MQTT-aiheessa 'opentherm/write'.
+
+Käytettävissä olevat OpenTherm-muuttujat ovat:
+### WRITE-arvot
+- chEnable: Boolean, pitäisikö keskuslämmitys kytkeä päälle
+- dhwEnable: Boolean, pitäisikö käyttöveden lämmitys kytkeä päälle
+- coolingEnable: Boolean, pitäisikö jäähdytys kytkeä päälle
+- roomTemp: Float-arvo termostaatin mittaamasta huonelämpötilasta
+- roomTempSet: Float-arvo pyydetystä huonelämpötilan asetusarvosta termostaatilla
+- chSetpoint: Float-arvo termostaatin laskemasta veden asetusarvosta
+- maxRelativeModulation: Modulaatiomäärä (0-100%), jonka lämpöpumppu saa käyttää
+- coolingControl: Jäähdytysmäärä (0-100%), jonka termostaatti pyytää lämpöpumpulta
+### READ AND WRITE -arvot
+- dhwSetpoint: Float-arvo nykyisestä käyttöveden asetusarvosta
+- maxTSet: Float-arvo, joka määrittää maksimiveden asetusarvon
+### READ-arvot
+- chPressure: Float-arvo mitatusta vesipaineesta
+- outsideTemp: Float-arvo mitatusta ulkolämpötilasta
+- inletTemp: Float-arvo mitatusta veden tulolämpötilasta
+- outletTemp: Float-arvo mitatusta veden lähtölämpötilasta
+- dhwTemp: Float-arvo mitatusta käyttövesilämpötilasta
+- relativeModulation: Nykyinen modulaatiomäärä (0-100%)
+- flameState: Boolean, tuottaako keskuslämmitys lämpöä
+- chState: Boolean, onko lämpöpumppu huone-/keskuslämmitystilassa
+- dhwState: Boolean, onko lämpöpumppu käyttövesitilassa
+- coolingState: Boolean, onko lämpöpumppu jäähdytystilassa
+- dhwSetUppBound: Kokonaisluku (0-127), maksimi käyttövesilämpötila. Oletus: 75
+- dhwSetLowBound: Kokonaisluku (0-127), minimi käyttövesilämpötila. Oletus: 40
+- chSetUppBound: Kokonaisluku (0-127), maksimi CH-vesilämpötila. Oletus: 65
+- chSetLowBound: Kokonaisluku (0-127), minimi CH-vesilämpötila. Oletus: 20
+
+## Viestin formaatti:
+[Tämän hetkinen lista dokumentoiduista dekoodatuista tavuista löytyy täältä](ProtocolByteDecrypt.md)
+
+## MQTT TLS-tuki:
+TLS-tuki MQTT:lle on tällä hetkellä toteutettu vain ESP32-versiolle. TLS on oletuksena poissa käytöstä ja sen voi ottaa käyttöön asetuksissa. Kun otat sen käyttöön, varmista, että MQTT-palvelimesi hyväksyy suojatut yhteydet heishamonilta, mukaan lukien PEM CA -varmenteen asettaminen (esim. itse allekirjoitettu). Lataa tekstitiedosto (plain text, pääte pem, esim. "CA.pem") varmenteesta heishamoniin asetussivun kautta. Varmenteen lataamisen jälkeen aktivoi TLS-tuki ja vaihda (normaaliasetuksissa) MQTT-portti 8883:een. !!TLS-ongelmiin ei tarjota tukea!! Google auttaa ongelmissa.
 
 ## Integraatio-esimerkkejä Open Source -kotiautomaatioon
 [Openhab2](Integrations/Openhab2)
 
-[Home Assistant](https://github.com/Egyras/HeishaMon/tree/master/Integrations/Home%20Assistant)
+[Home Assistant](Integrations/Home%20Assistant)
 
 [IOBroker Manual](Integrations/ioBroker_manual)
 
 [Domoticz](Integrations/Domoticz)
-

--- a/README_NL.md
+++ b/README_NL.md
@@ -1,98 +1,451 @@
-﻿[![Jion the Slack chat room](https://img.shields.io/badge/Slack-Join%20the%20chat%20room-orange)](https://join.slack.com/t/panasonic-wemos/shared_invite/enQtODg2MDY0NjE1OTI3LTgzYjkwMzIwNTAwZTMyYzgwNDQ1Y2QxYjkwODg3NjMyN2MyM2ViMDM3Yjc3OGE3MGRiY2FkYzI4MzZiZDVkNGE)
+[![Join us on Slack chat room](https://img.shields.io/badge/Slack-Join%20the%20chat%20room-orange)](https://join.slack.com/t/panasonic-wemos/shared_invite/enQtODg2MDY0NjE1OTI3LTgzYjkwMzIwNTAwZTMyYzgwNDQ1Y2QxYjkwODg3NjMyN2MyM2ViMDM3Yjc3OGE3MGRiY2FkYzI4MzZiZDVkNGE)
+[![Build binary](https://github.com/the78mole/HeishaMon/actions/workflows/main.yml/badge.svg)](https://github.com/the78mole/HeishaMon/actions/workflows/main.yml)
 
 
-# Panasonic H Series Aquarea lucht-water warmtepomp protocool
+# Panasonic H, J, K & L Series Aquarea lucht-water warmtepomp protocol
+
+Dit project maakt het mogelijk om informatie van de Panasonic Aquarea warmtepomp uit te lezen en de gegevens te rapporteren aan een MQTT-server of als JSON-formaat via HTTP.
 
 Eine deutschsprachige [README_DE.md](README_DE.md) findest du hier. \
-Een nederlandse vertaling [README_NL.md](README_NL.md) vind je hier.
+De Engelstalige originele documentatie vind je hier: [README.md](README.md). \
+Suomen kielellä [README_FI.md](README_FI.md) luettavissa täällä.
 
-Hulp bij het vertalen naar andere talen is zeer welkom.
-Help on translation to other languages are welcome.
+*Hulp bij het vertalen naar andere talen is van harte welkom.*
 
-##Huidige releases
+# Huidige releases
+De laatste release is beschikbaar [hier](https://github.com/Egyras/HeishaMon/releases). Het voor ESP8266 gecompileerde binary kan worden geïnstalleerd op een Wemos D1 mini, op het HeishaMon PCB en in het algemeen op elk ESP8266-gebaseerd board dat compatibel is met de Wemos build-instellingen (minimaal 4 MB flash). Je kunt de code ook downloaden en zelf compileren (zie vereiste bibliotheken hieronder). Het ESP32-S3 binary is voor de nieuwere, grote versie van heishamon.
 
-De huidige beta release versie is 0.5b. Het gecompileerde Bin file kan worden geinstalleerd op een WemosD1 mini (over het algemeen op ieder ESP8266 gebaseerd unit.). Je kunt ook de code zelf compileren (zie hieronder welke bibliotheken nodig zijn).
 
-## gebruik van de software
+# Gebruik van de software
+HeishaMon kan communiceren met de Panasonic Aquarea H, J, K en L-serie. [Door gebruikers bevestigde typen warmtepompen vind je hier](HeatPumpType.md) \
+Als je dit image zelf wilt compileren, zorg er dan voor dat je de genoemde bibliotheken gebruikt en ondersteuning voor een bestandssysteem op de ESP8266, selecteer daarvoor de juiste flash-optie in de Arduino IDE.
 
-De huidige arduino test image is in staat om gegevens te lezen van de Panasonic Aquarea H-series CN-CNT connector. 
-Als je de image zelf wil compileren gebruik dan in ieder geval de genoemde libraries met filesysteem ondersteuning op de esp8266, dus selecteer de juiste flash optie in de arduino ide. 
-Als de ESP voor de eerste keer start wordt er een open-wifi-hotspot zichtbaar waardoor het mogelijk is om de juiste wifi network en mqtt server settings in te stellen. 
-Als je om wat voor reden ook terug wilt naar de startup instelling, een dubbele reset op de esp8266 binnen 0.1 seconde is voldoende. De ESP zal het filesysteem formatteren, de wifi settings verwijderen en de wifi hotspot opnieuw opstarten. 
-Na het configureren en booten  is de wemos in staat om gegevens te lezen van en te zenden naar de warmtepomp. Deze communicatie vanuit de warmtepomp gaat naar de wemos op de in- en uitgang GPIO13/GPIO15. Je computer/uploader kan dus aangesloten blijven.
-Serial 1 kan worden gebruikt voor een andere seriele aansluiting ( alleenGND en TX van de ESP )om de debugging data te lezen.
+Bij het opstarten zonder geconfigureerd wifi wordt een open-wifi-hotspot zichtbaar waarmee je je wifi-netwerk en je MQTT-server kunt configureren. De configuratiepagina is beschikbaar op http://192.168.4.1 . \
 
-Alle ontvangen data wordt naar verschillende MQTT topics verstuurd. (zie de MQTT topics hoofdstuk voor verdere details). Er is ook een  panasonic_heat_pump/log' mqtt topic die debug logging verschaft en een hexdump van de ontvangen pakketten levert. (moet in het webportaal aangezet worden)
+Na het configureren en opstarten kan het image gegevens lezen van en communiceren met je warmtepomp. De GPIO13/GPIO15-verbinding wordt gebruikt voor communicatie, zodat je je computer/uploader aangesloten kunt laten als je dat wilt. \
+Serial 1 (GPIO2) kan worden gebruikt om een andere seriële verbinding (alleen GND en TX van het board) te verbinden om wat debug-gegevens uit te lezen.
 
-Ook is het mogelijk om een 1 wire netwerk aan te sluiten op GPIO4 welke dan in een separate mqtt topic de gegevens verzend. ( panasonic_heat_pump/1wire/sensorid). Zie voor meer informatie het ds18b20 1-wire support hoofdstuk.
+Alle ontvangen gegevens worden naar verschillende MQTT-topics gestuurd (zie hieronder voor topic-beschrijvingen). Er is ook een MQTT-topic 'panasonic_heat_pump/log' dat debug-logging en een hexdump van de ontvangen pakketten biedt (indien ingeschakeld in het webportaal).
 
-Het updaten van de software is simpel Ga naar het firmware menu en na ingave van username 'admin' en het wachtwoord wat tijdens de setup is opgegeven en je kunt dan de juiste binaire files uploaden.
+Je kunt een 1-wire netwerk aansluiten op GPIO4 dat rapporteert in aparte MQTT-topics (panasonic_heat_pump/1wire/sensorid).
 
-Een json output van alle ontvangen data ( warmtepomp en 1-wire) is beschikbaar op de url http://heishamon.local/json (vervang heishamon.local met het ip adres van jou heishamon apparaat als MDNS niet werkt voor jou).
+De software kan ook Watt meten op een S0-poort van twee kWh-meters. Je hoeft alleen GPIO12 en GND te verbinden met de S0 van één kWh-meter en als je een tweede kWh-meter nodig hebt, gebruik dan GPIO14 en GND. Het wordt gerapporteerd op MQTT-topic panasonic_heat_pump/s0/Watt/1 en panasonic_heat_pump/s0/Watt/2 en ook in de JSON-uitvoer. Je kunt 'Watt' in het vorige topic vervangen door 'Watthour' om de verbruiksteller in WattHour (per mqtt bericht) te krijgen, of door 'WatthourTotal' om het totale verbruik in WattHour te krijgen. Om de WatthourTotal te synchroniseren met je kWh-meter, publiceer de juiste waarde naar MQTT naar het topic panasonic_heat_pump/s0/WatthourTotal/1 of panasonic_heat_pump/s0/WatthourTotal/2 met de 'retain'-optie terwijl heishamon herstart.
 
-In de integratie folder kun je voorbeelden vinden hoe je jou automatiserings platform aan de heishamon.
+Firmware updaten is zo eenvoudig als naar het firmware-menu gaan en na authenticatie met gebruikersnaam 'admin' en wachtwoord 'heisha' (of een ander wachtwoord dat tijdens de setup is opgegeven), de binary daar uploaden.
 
-## Verdere informatie
-Hieronder kun je technische informatie vinden over het project. Hoe je eigen kabels te maken. Hoe je eigen PCB's te maken enz. 
+Een JSON-uitvoer van alle ontvangen gegevens (warmtepomp en 1-wire) is beschikbaar op de URL http://heishamon.local/json (vervang heishamon.local door het IP-adres van je heishamon-apparaat als MDNS niet werkt voor jou).
 
-## Aansluit details:
-CN-CNT TTL UART 9600,8,E,1  \
-Pin-out (van onder naar boven) \
+In de map 'integrations' vind je voorbeelden hoe je je automatiseringsplatform kunt koppelen aan de HeishaMon.
+
+# Regels-functionaliteit
+De regels-functionaliteit stelt je in staat om de warmtepomp te bedienen vanuit de HeishaMon zelf. Dit maakt het veel betrouwbaarder dan het omgaan met externe domotica via WiFi. Bij het plaatsen van een nieuwe regelset wordt deze direct gevalideerd en bij geldigheid gebruikt. Als een nieuwe regelset ongeldig is, wordt deze genegeerd en de oude regelset opnieuw geladen. Je kunt de console controleren voor feedback hierover. Als een nieuw geldige regelset de HeishaMon toch laat crashen, wordt deze automatisch uitgeschakeld bij de volgende herstart, zodat je wijzigingen kunt aanbrengen. Dit voorkomt dat de HeishaMon in een boot-lus terechtkomt.
+
+De technieken die in de regelbibliotheek worden gebruikt, stellen je in staat om te werken met zeer grote regelsets, maar de beste praktijk is om ze onder de 10.000 bytes te houden.
+
+Let op dat het sturen van opdrachten naar de warmtepomp asynchroon gebeurt. Opdrachten die aan het begin van je syntax naar de warmtepomp worden gestuurd, worden niet onmiddellijk weergegeven in de waarden van de warmtepomp later. Daarom moeten warmtepomp-waarden worden gelezen van de warmtepomp zelf in plaats van die op basis van waarden die je zelf bijhoudt.
+
+## Syntax
+Twee algemene regels: spaties zijn verplicht en puntkomma's worden gebruikt als einde-van-regel teken.
+
+### Variabelen
+De regelset gebruikt de volgende variabele structuur:
+
+- `#`: Globalen
+Deze variabelen zijn toegankelijk in de hele regelset, maar moeten worden gedefinieerd binnen een regelblok. Gebruik geen globalen voor al je variabelen, want dit gebruikt continu geheugen.
+
+- `$`: Lokalen
+Deze variabelen leven binnen een regelblok. Als een regelblok eindigt, worden deze variabelen opgeruimd en het gebruikte geheugen vrijgemaakt.
+
+- `@`: Warmtepomp-parameters
+Deze zijn dezelfde als vermeld op de documentatiepagina Manage Topics en op de HeishaMon-startpagina. De regelset volgt ook de R/W-logica zoals gebruikt via de MQTT en REST API. Dit betekent dat de leestopics verschillen van de schrijftopics. Het lezen van de warmtepompstatus gaat via `@Heatpump_State`, het wijzigen van de status via `@SetHeatpump`.
+
+- `%`: Datum- en tijdvariabelen
+Deze kunnen worden gebruikt voor datum- en tijdgebaseerde regels. Momenteel worden `%hour` (0-23), `%minute` (0-59), `%month` (1-12) en `day` (1-7) ondersteund. Alle zijn gewone integers. Een correcte NTP-configuratie is nodig om de juiste systeemdatum en -tijd in te stellen op de HeishaMon.
+
+- `?`: Thermostaatparameters
+Deze variabelen weerspiegelen parameters die worden gelezen van de aangesloten thermostaat bij gebruik van de OpenTherm-functionaliteit. De namen zijn hetzelfde voor lezen en schrijven, maar niet alle waarden ondersteunen lezen en/of schrijven.
+
+- `ds18b20#2800000000000000`: Dallas 1-wire temperatuurwaarden
+Gebruik deze variabelen om de temperatuur van de aangesloten sensoren te lezen. Deze waarden zijn uiteraard alleen-lezen. Het ID van de sensor moet na het hekje worden geplaatst.
+
+- `s0#watt[hour[total]]_?`: De S0-waarden voor poort 1 en 2. Vervang het vraagteken door het poortnummer.
+Bijvoorbeeld s0#watt_1 voor watt van poort 1 en s0#watthourtotal_2 voor totale watturren van poort 2.
+
+
+Als een variabele wordt aangeroepen maar nog geen waarde heeft, is de waarde `NULL`.
+
+Variabelen kunnen van het type Boolean (`1` of `0`), float (`3.14`), integer (`10`) en string zijn. Strings worden gedefinieerd met enkelvoudige of dubbele aanhalingstekens.
+
+### Gebeurtenissen of functies
+Regels worden geschreven in `event`- of `function`-blokken. Dit zijn blokken die worden geactiveerd wanneer er iets is gebeurd; ofwel een nieuwe warmtepomp- of thermostaatwaarde is ontvangen of een timer is afgegaan. Of kunnen worden gebruikt als gewone functies.
+
+```
+on [event] then
+  [...]
+end
+
+on [naam] then
+  [...]
+end
+```
+
+Gebeurtenissen kunnen Warmtepomp- of thermostaatparameters of timers zijn:
+```
+on @Heatpump_State then
+  [...]
+end
+
+on ?setpoint then
+  [...]
+end
+
+on timer=1 then
+  [...]
+end
+```
+
+Bij het definiëren van functies geef je je blok gewoon een naam en kun je het van overal aanroepen:
+```
+on foobar then
+  [...]
+end
+
+on @Heatpump_State then
+  foobar();
+end
+```
+
+Functies kunnen parameters hebben die je kunt aanroepen:
+```
+on foobar($a, $b, $c) then
+  [...]
+
+on @Heatpump_State then
+  foobar(1, 2, 3);
+end
+```
+
+Als je een functie aanroept met minder waarden dan de functie verwacht, hebben alle andere parameters een NULL-waarde.
+
+Er is momenteel één speciale functie die wordt aangeroepen bij het opstarten van het systeem of bij het opslaan van een nieuwe regelset:
+```
+on System#Boot then
+  [...]
+end
+```
+
+Deze speciale functie kan worden gebruikt om je globalen of bepaalde timers initieel in te stellen.
+
+### Operatoren
+Reguliere operatoren worden ondersteund met hun standaard associativiteit en prioriteit. Dit stelt je ook in staat om reguliere wiskunde te gebruiken.
+- `&&`: En
+- `||`: Of
+- `==`: Gelijk aan
+- `>=`: Groter dan of gelijk aan
+- `>`: Groter dan
+- `<`: Kleiner dan
+- `<=`: Kleiner dan of gelijk aan
+- `-`: Min
+- `%`: Modulo
+- `*`: Vermenigvuldigen
+- `/`: Delen
+- `+`: Plus
+- `^`: Macht
+
+Haakjes kunnen worden gebruikt om operatoren te prioriteren zoals in de reguliere wiskunde.
+
+### Functies
+- `coalesce`
+Geeft de eerste waarde terug die niet `NULL` is. Bijv. `$b = NULL; $a = coalesce($b, 1);` geeft 1 terug. Deze functie accepteert een onbeperkt aantal argumenten.
+
+- `max`
+Geeft de maximale waarde van de invoerparameters terug.
+
+- `min`
+Geeft de minimale waarde van de invoerparameters terug.
+
+- `isset`
+Geeft boolean true terug wanneer de invoervariabele nog `NULL` is, in alle andere gevallen false.
+
+- `round`
+Rondt de invoer-float af op het dichtstbijzijnde gehele getal.
+
+- `floor`
+De grootste gehele getal waarde die kleiner dan of gelijk aan de invoer-float is.
+
+- `ceil`
+De kleinste gehele getal waarde die groter dan of gelijk aan de invoer-float is.
+
+- `setTimer`
+Stelt een timer in die na X seconden afgaat. De eerste parameter is het timernummer en de tweede parameter het aantal seconden voordat hij afgaat. Een timer gaat slechts één keer af en moet opnieuw worden ingesteld voor terugkerende gebeurtenissen.
+
+- `print`
+Drukt een waarde af op de console.
+
+- `concat`
+Voegt verschillende waarden samen tot een gecombineerde string. Bijv.: `@SetCurves = concat('{zone1:{heat:{target:{high:', @Z1_Heat_Curve_Target_High_Temp, ',low:32}}}}');`
+
+- `gpio`
+Maakt het instellen of ophalen van een GPIO-toestand mogelijk. Bij aanroep met één argument wordt de GPIO-toestand geretourneerd. Bij aanroep met twee argumenten wordt de toestand van een GPIO ingesteld. Deze functie stelt alleen digitale pinnen in, zodat de toestand slechts 0 of 1 kan zijn. De twee relais op de grote heishamon zijn gpio21 en gpio47. De gebruikers-configureerbare extra GPIO's (zie hieronder) kunnen ook worden aangesproken via hun pinnummer. Zie het voorbeeld om de relais elke twee seconden om te schakelen.
+
+```
+on System#Boot then
+   setTimer(10, 2);
+end
+
+on timer=10 then
+   setTimer(20, 2);
+   gpio(21,0);
+   gpio(47,1);
+end
+
+on timer=20 then
+   setTimer(10, 2);
+   gpio(21,1);
+   gpio(47,0);
+end
+```
+
+### Condities
+De enige ondersteunde condities zijn `if`, `else` en `elseif`:
+
+```
+if [conditie] then
+  [...]
+else
+  if [conditie] then
+    [...]
+  end
+end
+```
+
+```
+if [conditie] then
+  [...]
+elseif [conditie] then
+  if [conditie] then
+    [...]
+  else
+    [...]
+  end
+elseif [conditie] then
+  [...]
+else
+  [...]
+end
+```
+
+### Voorbeelden
+
+*WAR berekenen (Weerafhankelijke regeling)*
+```
+on calcWar($Ta1, $Tb1, $Ta2, $Tb2) then
+	#maxTa = $Ta1;
+
+	if @Outside_Temp >= $Tb1 then
+		#maxTa = $Ta1;
+	elseif @Outside_Temp <= $Tb2 then
+		#maxTa = $Ta2;
+	else
+		#maxTa = $Ta1 + (($Tb1 - @Outside_Temp) * ($Ta2 - $Ta1) / ($Tb1 - $Tb2));
+	end
+end
+```
+
+*Thermostaatinstelpunt*
+```
+on ?roomTemp then
+	calcWar(32, 14, 41, -4);
+
+	$margin = 0.25;
+
+	if ?roomTemp > (?roomTempSet + $margin) then
+		if @Heatpump_State == 1 then
+			@SetHeatpump = 0;
+		end
+	elseif ?roomTemp < (?roomTempSet - $margin) then
+		if @Heatpump_State == 0 then
+			@SetHeatpump = 1;
+		end
+	else
+		@SetZ1HeatRequestTemperature = round(#maxTa);
+	end
+end
+```
+
+# Fabrieksreset
+Een fabrieksreset kan worden uitgevoerd via de webinterface, maar als de webinterface niet beschikbaar is, kun je een dubbele reset uitvoeren. De dubbele reset moet niet te snel maar ook niet te langzaam worden uitgevoerd. Meestal werkt een halve seconde tussen beide resets. Om aan te geven dat de dubbele reset een fabrieksreset heeft uitgevoerd, knippert de blauwe LED snel (Je moet nu opnieuw op reset drukken om HeishaMon normaal opnieuw op te starten, waarbij een WiFi-hotspot zichtbaar moet zijn).
+
+# Verdere informatie
+Hieronder vind je enkele technische details over het project. Hoe je je eigen kabels bouwt. Hoe je je eigen PCB bouwt enz.
+
+## Verbindingsdetails:
+Communicatie kan worden tot stand gebracht via een van de twee aansluitingen: CN-CNT of CN-NMODE. Als je een bestaande Panasonic CZ-TAW1 WiFi-interface hebt die je wilt vervangen door HeishaMon, is het slechts een kwestie van de kabel uit de CZ-TAW1 halen en opnieuw verbinden met je HeishaMon-apparaat. Het is echter niet mogelijk om HeishaMon en de originele CZ-TAW1-module samen te gebruiken als actief apparaat. Het is wel mogelijk om HeishaMon in de "Alleen luisteren"-modus te zetten, waardoor HeishaMon en de originele CZ-TAW1-module naast elkaar kunnen bestaan. Het enige nadeel hiervan is dat HeishaMon geen opdrachten kan sturen en de optionele PCB-optie niet kan gebruiken.
+
+Communicatieparameters: TTL 5V UART 9600,8,E,1  \
+ \
+CN-CNT Pin-indeling (van boven naar beneden) \
 1 - +5V (250mA)  \
-2 - 0-5V TX  \
-3 - 0-5 RX  \
+2 - 0-5V TX (van de warmtepomp) \
+3 - 0-5V RX (naar de warmtepomp)\
 4 - +12V (250mA) \
-5 - GND
+5 - GND \
+ \
+CN-NMODE Pin-indeling (van links naar rechts) \
+"Let op! Zoals op de PCB staat afgedrukt, is de linkerpin pin 4 en de rechterpin is pin 1. Tel niet 1 tot 4 van links!  \
+4 - +5V (250mA)  \
+3 - 0-5V TX (van de warmtepomp) \
+2 - 0-5V RX (naar de warmtepomp) \
+1 - GND
 
-## Waar kun je connectoren kopen
-[RS-Online orders](Connectors_RSO.md) \
-[Conrad orders](Connectors_Conrad.md)
+HeishaMon ontvangt stroom van Panasonic via de kabel (5V stroom).
 
-Gebruik  24 AWG afgeschermde 4 aderige kabel.
-Voeg tevens wat 24 AWG afgeschermde 4 aderige kabel toe (lengte zelf te bepalen).
+## Verbinding over lange afstand
+Het is mogelijk om de HeishaMon over een lange afstand aan te sluiten. Tot 5 meter werkt met normale bekabeling. Voor grotere afstanden is een TTL-naar-RS485-configuratie zoals weergegeven in de afbeelding hieronder mogelijk. Dit vereist echter dat HeishaMon extern wordt gevoed met 5V stroom (bijvoorbeeld via een USB-kabel).
 
-## Hoe aan te sluiten
-
-Momenteel zijn de PCB's in (beta) productie. wij adviseren om nog even te wachten met bestellen omdat de testen nog lopen. Binnenkort kun je een van de PCB ontwerpen bestellen rechtstreeks bij de project eigenaren. Maar natuurlijk delen wij hier de schema's ook. De volgende mogelijke oplossingen zijn of worden momenteel getest.
-
-
-[PCD Designs from the project members](PCB_Designs.md) \
-[Picture Wemos D1 beta](WEMOSD1.JPG) \
-[Picture ESP12-F](New_PCB.jpeg)
+![TTL-over-RS485 HeishaMon lange afstand verbinding](optional-long-distance-heishamon.png)
 
 
+## Waar je connectoren kunt kopen
+[RS-Online bestellingen](Connectors_RSO.md)
+
+[Conrad bestellingen](Connectors_Conrad.md)
+
+Gebruik een afgeschermde 24 AWG 4-aderige kabel.
 
 
-## Het bouwen van de test arduino image
-boards: \
-esp8266 by esp8266 community version 2.6.3  Arduino  
-[libs we use](LIBSUSED.md)
+## De HeishaMon-hardware zelf
+De PCB's die nodig zijn om verbinding te maken met de warmtepomp zijn ontworpen door projectleden en worden hieronder vermeld. Het belangrijkste onderdeel van de hardware is een niveauverschuiving van 5V van Panasonic naar 3,3V van de HeishaMon en een GPIO13/GPIO15-activeringslijnen na het opstarten. \
+[PCB-ontwerpen van de projectleden](PCB_Designs.md) \
+[Foto Wemos D1 Beta](WEMOSD1.JPG) \
+[Foto ESP12-F](NewHeishamon.JPG)
+
+Om het makkelijk te maken kun je een compleet PCB bestellen bij sommige projectleden: \
+[Tindie-winkel](https://www.tindie.com/stores/thehognl/) van Igor Ybema (ook bekend als TheHogNL) uit Nederland
+
+## Het Arduino-image zelf bouwen
+Boards: \
+esp8266 by esp8266 community version 3.0.2 [Arduino](https://github.com/esp8266/Arduino/releases/tag/3.0.2)
+
+Alle [bibliotheken die we gebruiken](LIBSUSED.md) die nodig zijn voor het compileren.
 
 
-## MQTT topics
-[Huidige lijst van gedocumenteerde MQTT onderwerpen kun je hier vinden](MQTT-Topics.md)
+## MQTT-topics
+[Huidige lijst van gedocumenteerde MQTT-topics vind je hier](MQTT-Topics.md)
 
-## DS18b20 1-wire support
-De software ondersteund ook ds18b20 1-wire temperatuur sensor uitlezing. Een standaard 1-wire configuratie (met 4.7kohm pull-up weerstand) aangesloten op GPIO4 leest iedere 30 secondende waarden en stuurt die naar de panasonic_heat_pump/1wire/"sensor-hex-address" topic.
+## Communicatiebetrouwbaarheid
+Berichten van HeishaMon naar de warmtepomp worden af en toe verworpen, vooral als meerdere instellingen binnen korte tijd worden gewijzigd. Het is niet haalbaar voor HeishaMon om alle verworpen berichten opnieuw te verzenden, dus gebruikers moeten hun eigen herhaallogica implementeren.
 
-## Protocol info packet:
+De aanbevolen herhaallogica is als volgt:
+1. Na het wijzigen van een warmtepomp-instelling via HeishaMon, wacht je tot HeishaMon meldt dat de instelling is gewijzigd.
+2. Als de instelling na 10 seconden niet is bijgewerkt, stel je deze opnieuw in.
 
-Om informatie te krijgen van de warmtepomp, moet het volgende "magic packet" verstuurd worden naar de CN-CNT: 
+Dit kan op de HeishaMon zelf worden geïmplementeerd met Regels, zoals in dit voorbeeld:
+```
+on StopExternalControl then
+  if @External_Control != 0 then
+    @SetExternalControl = 0;
+    settimer(9,10);
+  end
+end
 
-`71 6c 01 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 12`
+on timer=9 then
+  if @External_Control != 0 then
+    @SetExternalControl = 0;
+  end
+end
+```
+
+## EEPROM-waarschuwing
+Tot op heden weten we niet hoe de opdrachten die naar de warmtepomp worden gestuurd, worden verwerkt in de warmtepomp zelf. Waarschijnlijk worden veel opdrachten naar EEPROM geschreven om beschikbaar te zijn na een stroomuitval, zoals het instellen van de DHW-temperatuur. Een EEPROM kan veel schrijfbewerkingen aan, maar er is een limiet. En we kennen de limiet ook niet. Zorg er dus voor dat je de warmtepomp niet overlaadt met te veel opdrachten. Elke seconde is veel te frequent. Een paar per uur, per instelling, is waarschijnlijk prima. Bovendien is een warmtepomp een traag verwarmings-(koel-)apparaat, dus zo frequent wijzigingen aanbrengen is waarschijnlijk toch niet zinvol.
+
+## DS18b20 1-wire ondersteuning
+De software ondersteunt ook het uitlezen van DS18B20 1-wire temperatuursensoren. Een correcte 1-wire configuratie (met 4,7kOhm pull-up weerstand) aangesloten op GPIO4 wordt elke geconfigureerde seconden (minimaal 5) gelezen en gestuurd naar het topic panasonic_heat_pump/1wire/"sensor-hex-adres". Op de kant-en-klare boards is deze 4,7kOhm weerstand al geïnstalleerd.
+
+## Relaisbesturing op het grote board
+De nieuwere, grote, heishamon bevat twee ingebouwde relais die kunnen worden in- en uitgeschakeld via MQTT-opdrachten. De relais kunnen worden gebruikt voor elke contactschakelaar, zelfs 230V netspanning (max. 5A). Om het relais te bedienen, stuur gewoon een waarde van 1 of 0 naar het MQTT-topic "panasonic_heat_pump/gpio/relay/one" voor relais één of "panasonic_heat_pump/gpio/relay/two" voor relais twee.
+
+## Gebruikers-configureerbare extra GPIO's
+Naast de vaste relaispennen stelt HeishaMon een aantal gebruikers-configureerbare GPIO-pinnen beschikbaar die elk onafhankelijk kunnen worden ingesteld op Ingang (pull-up), Ingang of Uitgang via het instellingen-webmenu.
+
+**Beschikbare pinnen per platform:**
+- **ESP8266:** 3 extra GPIO's (pinnen 1, 3, 16)
+- **ESP32:** 5 extra GPIO's (pinnen 33–37); relaispennen 21 en 47 blijven vast
+
+De modus voor elke pin wordt opgeslagen in de instellingen en toegepast bij het opstarten en wanneer instellingen worden opgeslagen.
+
+**Uitgangs-GPIO's bedienen via MQTT:**
+Stuur `1`, `0`, `on`, `off`, `true` of `false` naar:
+```
+panasonic_heat_pump/gpio/extra/N
+```
+waarbij `N` de 1-gebaseerde index van de extra GPIO is (bijv. `extra/1` voor de eerste extra pin).
+
+**GPIO-toestanden lezen via MQTT:**
+Ingangs- en uitgangstoestanden worden automatisch gepubliceerd naar dezelfde topics bij wijziging en bij de eerste MQTT-verbinding (retained).
+
+**HTTP API:**
+Je kunt alle extra GPIO-toestanden als JSON lezen via een GET-verzoek:
+```
+GET /gpio
+```
+Voorbeeldantwoord:
+```json
+[{"pin":33,"mode":2,"state":1},{"pin":34,"mode":0,"state":0}, ...]
+```
+waarbij `mode` 0 = Ingang (pull-up), 1 = Ingang, 2 = Uitgang is.
+
+Een uitgangspin instellen via HTTP POST:
+```
+POST /gpio?pin=N&value=1
+```
+
+**Extra GPIO's gebruiken in regels:**
+De `gpio()`-regelfunctie werkt met de extra GPIO-pinnen via hun fysieke pinnummer, hetzelfde als de relaispennen.
+
+## OpenTherm-ondersteuning
+Als je heishamon-board OpenTherm ondersteunt, kan de software ook worden gebruikt om OpenTherm-informatie van een compatibele thermostaat via MQTT of JSON door te sturen naar je thuisautomatisering. Als je OpenTherm-ondersteuning inschakelt in de instellingen, verschijnt er een nieuw tabblad op de webpagina met OpenTherm-waarden. Sommige zijn van het type R(ead) en sommige zijn W(rite), en sommige zijn beide. Read betekent dat de thermostaat die informatie van de heishamon kan lezen. Je verstrekt die informatie via MQTT (of via de regels) door deze waarde bij te werken op het MQTT-topic 'opentherm/read'. De Write-waarden zijn informatie van de thermostaat, zoals 'roomTemp'. Deze zijn beschikbaar op het MQTT-topic 'opentherm/write'.
+
+De beschikbare OpenTherm-variabelen zijn:
+### WRITE-waarden
+- chEnable: Boolean die aangeeft of centrale verwarming ingeschakeld moet worden
+- dhwEnable: Boolean die aangeeft of DHW-verwarming ingeschakeld moet worden
+- coolingEnable: Boolean die aangeeft of koeling ingeschakeld moet worden
+- roomTemp: Float-waarde van de gemeten kamertemperatuur door de thermostaat
+- roomTempSet: Float-waarde van het gevraagde kamertemperatuur-instelpunt op de thermostaat
+- chSetpoint: Float-waarde van het berekende water-instelpunt door de thermostaat
+- maxRelativeModulation: Modulatiehoeveelheid (0-100%) die de warmtepomp mag gebruiken
+- coolingControl: Koelhoeveelheid (0-100%) die de thermostaat van de warmtepomp vraagt
+### READ AND WRITE-waarden
+- dhwSetpoint: Float-waarde van het huidige DHW-instelpunt
+- maxTSet: Float-waarde die het maximale water-instelpunt definieert
+### READ-waarden
+- chPressure: Float-waarde van de gemeten waterdruk
+- outsideTemp: Float-waarde van de gemeten buitentemperatuur
+- inletTemp: Float-waarde van de gemeten waterinlaattemperatuur
+- outletTemp: Float-waarde van de gemeten wateruitlaattemperatuur
+- dhwTemp: Float-waarde van de gemeten DHW-temperatuur
+- relativeModulation: Huidige modulatiehoeveelheid (0-100%)
+- flameState: Boolean die aangeeft of de centrale verwarming warmte levert
+- chState: Boolean die aangeeft of de warmtepomp in ruimte-/centrale verwarmingsmodus is
+- dhwState: Boolean die aangeeft of de warmtepomp in DHW-modus is
+- coolingState: Boolean die aangeeft of de warmtepomp in koel-modus is
+- dhwSetUppBound: Integer (0-127), maximale DHW-temperatuur. Standaard: 75
+- dhwSetLowBound: Integer (0-127), minimale DHW-temperatuur. Standaard: 40
+- chSetUppBound: Integer (0-127), maximale CH-watertemperatuur. Standaard: 65
+- chSetLowBound: Integer (0-127), minimale CH-watertemperatuur. Standaard: 20
 
 ## Protocol byte decrypt info:
+[Huidige lijst van gedocumenteerde gedecodeerde bytes vind je hier](ProtocolByteDecrypt.md)
 
-[Huidige lijst van gedocumenteerde bytes decrypted kan hier gevonden worden](ProtocolByteDecrypt.md)
-## Integration Examples for Opensource automation systems
+## MQTT TLS-ondersteuning:
+TLS-ondersteuning voor MQTT is momenteel alleen geïmplementeerd voor de ESP32-versie. TLS is standaard uitgeschakeld en kan worden ingeschakeld in de instellingen. Zorg er bij het inschakelen voor dat je MQTT-broker beveiligde verbindingen van heishamon accepteert, inclusief het instellen van een PEM CA-certificaat (bijv. zelfondertekend). Upload een tekstbestand (plain text met suffix pem, bijv. "CA.pem") van het certificaat naar heishamon in het instellingenscherm. Na het uploaden van het certificaat, activeer TLS-ondersteuning en schakel (in normale setups) de MQTT-poort over naar 8883. !!Er is geen ondersteuning voor TLS-problemen!! Google kan je helpen bij problemen.
 
+## Integratie-voorbeelden voor Open Source-automatiseringssystemen
 [Openhab2](Integrations/Openhab2)
 
-[Home Assistant](https://github.com/Egyras/HeishaMon/tree/master/Integrations/Home%20Assistant)
+[Home Assistant](Integrations/Home%20Assistant)
 
-[IOBroker Manual](Integrations/ioBroker_manual)
+[IOBroker Handleiding](Integrations/ioBroker_manual)
 
 [Domoticz](Integrations/Domoticz)
-
-
-


### PR DESCRIPTION
Bring DE, NL, and FI translations up to date with the current English README, adding all missing sections: Rules functionality, Factory reset, Long distance connection, Large board relay control, User-configurable extra GPIO, OpenTherm support, Communication reliability, EEPROM warning, and MQTT TLS support.