### PR TITLE
Add raw data publishing setting.

### DIFF
--- a/HeishaMon/HeishaMon.ino
+++ b/HeishaMon/HeishaMon.ino
@@ -500,7 +500,7 @@ void mqtt_reconnect()
         resetlastalldatatime(); //resend all heatpump values to mqtt
       }
       //use this to receive valid heishamon raw data from other heishamon to debug this OT code
-      if (heishamonSettings.publishRawData && heishamonSettings.listenonly) {
+      if (heishamonSettings.listenRawData && heishamonSettings.listenonly) {
         mqtt_client.subscribe((char*)"panasonic_heat_pump/raw/data"); //subscribe to raw heatpump data over MQTT
       }
     }
@@ -970,7 +970,7 @@ void mqtt_callback(char* topic, byte* payload, unsigned int length) {
       char* topic_sendcommand = topic_command + strlen(mqtt_topic_commands) + 1; //strip the first 9 "commands/" from the topic to get what we need
       send_heatpump_command(topic_sendcommand, msg, send_command, log_message, heishamonSettings.optionalPCB);
     //use this to receive valid heishamon raw data from other heishamon to debug this OT code
-    } else if (heishamonSettings.publishRawData && strcmp((char*)"panasonic_heat_pump/raw/data", topic) == 0) {  // check for raw heatpump input
+    } else if (heishamonSettings.listenRawData && strcmp((char*)"panasonic_heat_pump/raw/data", topic) == 0) {  // check for raw heatpump input
       sprintf_P(log_msg, PSTR("Received raw heatpump data from MQTT"));
       log_message(log_msg);
       decode_heatpump_data(msg, actData, mqtt_client, log_message, heishamonSettings.mqtt_topic_base, heishamonSettings.updateAllTime);

--- a/HeishaMon/HeishaMon.ino
+++ b/HeishaMon/HeishaMon.ino
@@ -500,12 +500,9 @@ void mqtt_reconnect()
         resetlastalldatatime(); //resend all heatpump values to mqtt
       }
       //use this to receive valid heishamon raw data from other heishamon to debug this OT code
-//#define RAWDEBUG
-#ifdef RAWDEBUG
-      if ( heishamonSettings.listenonly) {
+      if (heishamonSettings.publishRawData && heishamonSettings.listenonly) {
         mqtt_client.subscribe((char*)"panasonic_heat_pump/raw/data"); //subscribe to raw heatpump data over MQTT
       }
-#endif
     }
 //#ifdef TLS_SUPPORT // error state is useful in any case
     else {
@@ -741,25 +738,21 @@ bool readSerial()
             log_message(_F("Extra data available on this heatpump"));
             extraDataBlockAvailable = true; //request for extra data next run
           }
-          #ifdef RAWDEBUG
-          {
+          if (heishamonSettings.publishRawData) {
             char mqtt_topic[256];
             sprintf(mqtt_topic, "%s/raw/data", heishamonSettings.mqtt_topic_base);
             mqtt_client.publish(mqtt_topic, (const uint8_t *)actData, DATASIZE, false); //do not retain this raw data
           }
-          #endif
           data_length = 0;
           return true;
         } else if (data[3] == 0x21) { //decode the new model extra data block
           extraDataBlockAvailable = true; //set the flag to true so we know we can request this data always
           decode_heatpump_data_extra(data, actDataExtra, mqtt_client, log_message, heishamonSettings.mqtt_topic_base, heishamonSettings.updateAllTime);
-          #ifdef RAWDEBUG
-          {
+          if (heishamonSettings.publishRawData) {
             char mqtt_topic[256];
             sprintf(mqtt_topic, "%s/raw/dataextra", heishamonSettings.mqtt_topic_base);
             mqtt_client.publish(mqtt_topic, (const uint8_t *)actDataExtra, DATASIZE, false); //do not retain this raw data
           }
-          #endif
           data_length = 0;
           return true;
         } else {
@@ -977,13 +970,11 @@ void mqtt_callback(char* topic, byte* payload, unsigned int length) {
       char* topic_sendcommand = topic_command + strlen(mqtt_topic_commands) + 1; //strip the first 9 "commands/" from the topic to get what we need
       send_heatpump_command(topic_sendcommand, msg, send_command, log_message, heishamonSettings.optionalPCB);
     //use this to receive valid heishamon raw data from other heishamon to debug this OT code
-#ifdef RAWDEBUG
-    } else if (strcmp((char*)"panasonic_heat_pump/raw/data", topic) == 0) {  // check for raw heatpump input
+    } else if (heishamonSettings.publishRawData && strcmp((char*)"panasonic_heat_pump/raw/data", topic) == 0) {  // check for raw heatpump input
       sprintf_P(log_msg, PSTR("Received raw heatpump data from MQTT"));
       log_message(log_msg);
       decode_heatpump_data(msg, actData, mqtt_client, log_message, heishamonSettings.mqtt_topic_base, heishamonSettings.updateAllTime);
       memcpy(actData, msg, DATASIZE);
-#endif
     } else if (strncmp(topic_command, mqtt_topic_opentherm_read, strlen(mqtt_topic_opentherm_read)) == 0)  {
       char* topic_otcommand = topic_command + strlen(mqtt_topic_opentherm_read) + 1; //strip the opentherm subtopic from the topic
       mqttOTCallback(topic_otcommand, msg);

--- a/HeishaMon/htmlcode.h
+++ b/HeishaMon/htmlcode.h
@@ -1362,6 +1362,14 @@ function ShowHideDallasTable(cb){
 function ShowHideS0Table(cb){
   document.getElementById('s0settings').style.display=cb.checked?'block':'none';
 }
+function syncRawDataSettings(changed){
+  var publish=document.getElementsByName('publishRawData')[0];
+  var listen=document.getElementsByName('listenRawData')[0];
+  if(!publish||!listen)return;
+  if(changed=='publish'&&publish.checked)listen.checked=false;
+  if(changed=='listen'&&listen.checked)publish.checked=false;
+  if(!changed&&publish.checked&&listen.checked)listen.checked=false;
+}
 function changeMinWatt(port){
   var ppkwh=document.getElementById('s0_ppkwh_'+port).value;
   var interval=document.getElementById('s0_interval_'+port).value;
@@ -1565,7 +1573,8 @@ static const char settingsForm2[] FLASHPROG = R"====(
     <div class='setting-row'><label class='setting-label'>Debug log to MQTT from start</label><div class='checkbox-wrap'><input type='checkbox' name='logMqtt' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Debug hexdump from start</label><div class='checkbox-wrap'><input type='checkbox' name='logHexdump' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Debug log to serial1 (GPIO2)</label><div class='checkbox-wrap'><input type='checkbox' name='logSerial1' value='enabled'></div></div>
-    <div class='setting-row'><label class='setting-label'>Publish raw heatpump data</label><div class='checkbox-wrap'><input type='checkbox' name='publishRawData' value='enabled'></div></div>
+    <div class='setting-row'><label class='setting-label'>Publish raw heatpump data to MQTT</label><div style='display:flex;align-items:center;gap:10px'><div class='checkbox-wrap'><input type='checkbox' name='publishRawData' value='enabled' onchange="syncRawDataSettings('publish')"></div><span class='setting-hint'>For a production HeishaMon connected to a heatpump.</span></div></div>
+    <div class='setting-row'><label class='setting-label'>Listen to raw heatpump data from MQTT</label><div style='display:flex;align-items:center;gap:10px'><div class='checkbox-wrap'><input type='checkbox' name='listenRawData' value='enabled' onchange="syncRawDataSettings('listen')"></div><span class='setting-hint'>For a test HeishaMon fed by another device. Cannot be combined with publishing.</span></div></div>
     <div class='setting-row'><label class='setting-label'>Emulate optional PCB</label><div class='checkbox-wrap'><input type='checkbox' name='optionalPCB' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Enable Opentherm processing</label><div class='checkbox-wrap'><input type='checkbox' name='opentherm' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Force load rules on boot</label><div style='display:flex;align-items:center;gap:10px'><div class='checkbox-wrap'><input type='checkbox' name='force_rules' value='enabled'></div><span class='setting-hint' style='display:block;margin-top:4px'>Rules load normally, but skip after crashes to prevent boot loops. Enable to override.</span></div></div>
@@ -1667,7 +1676,8 @@ static const char settingsForm2[] FLASHPROG = R"====(
     <div class='setting-row'><label class='setting-label'>Debug log to MQTT from start</label><div class='checkbox-wrap'><input type='checkbox' name='logMqtt' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Debug hexdump from start</label><div class='checkbox-wrap'><input type='checkbox' name='logHexdump' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Debug log USB</label><div class='checkbox-wrap'><input type='checkbox' name='logSerial1' value='enabled'></div></div>
-    <div class='setting-row'><label class='setting-label'>Publish raw heatpump data</label><div class='checkbox-wrap'><input type='checkbox' name='publishRawData' value='enabled'></div></div>
+    <div class='setting-row'><label class='setting-label'>Publish raw heatpump data to MQTT</label><div style='display:flex;align-items:center;gap:10px'><div class='checkbox-wrap'><input type='checkbox' name='publishRawData' value='enabled' onchange="syncRawDataSettings('publish')"></div><span class='setting-hint'>For a production HeishaMon connected to a heatpump.</span></div></div>
+    <div class='setting-row'><label class='setting-label'>Listen to raw heatpump data from MQTT</label><div style='display:flex;align-items:center;gap:10px'><div class='checkbox-wrap'><input type='checkbox' name='listenRawData' value='enabled' onchange="syncRawDataSettings('listen')"></div><span class='setting-hint'>For a test HeishaMon fed by another device. Cannot be combined with publishing.</span></div></div>
     <div class='setting-row'><label class='setting-label'>Emulate optional PCB</label><div class='checkbox-wrap'><input type='checkbox' name='optionalPCB' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Enable Opentherm processing</label><div class='checkbox-wrap'><input type='checkbox' name='opentherm' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Enable CZ-TAW1 proxy port</label><div class='checkbox-wrap'><input type='checkbox' name='proxy' value='enabled'></div></div>
@@ -1772,6 +1782,7 @@ R"====(
           if(el[0].type.indexOf('select')>-1){var ch=el[0].childNodes;for(var x=0;x<ch.length;x++){if(ch[x].value==j[k])ch[x].selected=true;}}
         }
       }
+      syncRawDataSettings();
       document.getElementById('loading_settings').style.display='none';
       document.getElementById('settings_form').style.display='block';
       changeMinWatt(1);changeMinWatt(2);

--- a/HeishaMon/htmlcode.h
+++ b/HeishaMon/htmlcode.h
@@ -1565,6 +1565,7 @@ static const char settingsForm2[] FLASHPROG = R"====(
     <div class='setting-row'><label class='setting-label'>Debug log to MQTT from start</label><div class='checkbox-wrap'><input type='checkbox' name='logMqtt' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Debug hexdump from start</label><div class='checkbox-wrap'><input type='checkbox' name='logHexdump' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Debug log to serial1 (GPIO2)</label><div class='checkbox-wrap'><input type='checkbox' name='logSerial1' value='enabled'></div></div>
+    <div class='setting-row'><label class='setting-label'>Publish raw heatpump data</label><div class='checkbox-wrap'><input type='checkbox' name='publishRawData' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Emulate optional PCB</label><div class='checkbox-wrap'><input type='checkbox' name='optionalPCB' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Enable Opentherm processing</label><div class='checkbox-wrap'><input type='checkbox' name='opentherm' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Force load rules on boot</label><div style='display:flex;align-items:center;gap:10px'><div class='checkbox-wrap'><input type='checkbox' name='force_rules' value='enabled'></div><span class='setting-hint' style='display:block;margin-top:4px'>Rules load normally, but skip after crashes to prevent boot loops. Enable to override.</span></div></div>
@@ -1666,6 +1667,7 @@ static const char settingsForm2[] FLASHPROG = R"====(
     <div class='setting-row'><label class='setting-label'>Debug log to MQTT from start</label><div class='checkbox-wrap'><input type='checkbox' name='logMqtt' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Debug hexdump from start</label><div class='checkbox-wrap'><input type='checkbox' name='logHexdump' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Debug log USB</label><div class='checkbox-wrap'><input type='checkbox' name='logSerial1' value='enabled'></div></div>
+    <div class='setting-row'><label class='setting-label'>Publish raw heatpump data</label><div class='checkbox-wrap'><input type='checkbox' name='publishRawData' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Emulate optional PCB</label><div class='checkbox-wrap'><input type='checkbox' name='optionalPCB' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Enable Opentherm processing</label><div class='checkbox-wrap'><input type='checkbox' name='opentherm' value='enabled'></div></div>
     <div class='setting-row'><label class='setting-label'>Enable CZ-TAW1 proxy port</label><div class='checkbox-wrap'><input type='checkbox' name='proxy' value='enabled'></div></div>

--- a/HeishaMon/webfunctions.cpp
+++ b/HeishaMon/webfunctions.cpp
@@ -228,6 +228,8 @@ void loadSettings(settingsStruct *heishamonSettings) {
           heishamonSettings->logHexdump = ( jsonDoc[F("logHexdump")] == "enabled" ) ? true : false;
           heishamonSettings->logSerial1 = ( jsonDoc[F("logSerial1")] == "enabled" ) ? true : false;
           heishamonSettings->publishRawData = ( jsonDoc[F("publishRawData")] == "enabled" ) ? true : false;
+          heishamonSettings->listenRawData = ( jsonDoc[F("listenRawData")] == "enabled" ) ? true : false;
+          if (heishamonSettings->publishRawData && heishamonSettings->listenRawData) heishamonSettings->listenRawData = false;
           heishamonSettings->optionalPCB = ( jsonDoc[F("optionalPCB")] == "enabled" ) ? true : false;
           heishamonSettings->opentherm = ( jsonDoc[F("opentherm")] == "enabled" ) ? true : false;
 #ifdef ESP32          
@@ -452,6 +454,11 @@ void settingsToJson(JsonDocument &jsonDoc, settingsStruct *heishamonSettings) {
   } else {
     jsonDoc[F("publishRawData")] = "disabled";
   }
+  if (heishamonSettings->listenRawData) {
+    jsonDoc[F("listenRawData")] = "enabled";
+  } else {
+    jsonDoc[F("listenRawData")] = "disabled";
+  }
   if (heishamonSettings->optionalPCB) {
     jsonDoc[F("optionalPCB")] = "enabled";
   } else {
@@ -605,6 +612,7 @@ int saveSettings(struct webserver_t *client, settingsStruct *heishamonSettings) 
   jsonDoc[F("logHexdump")] = String("disabled");
   jsonDoc[F("logSerial1")] = String("disabled");
   jsonDoc[F("publishRawData")] = String("disabled");
+  jsonDoc[F("listenRawData")] = String("disabled");
   jsonDoc[F("optionalPCB")] = String("disabled");
   jsonDoc[F("opentherm")] = String("disabled");
 
@@ -654,6 +662,8 @@ int saveSettings(struct webserver_t *client, settingsStruct *heishamonSettings) 
       jsonDoc[F("logSerial1")] = tmp->value;
     } else if (strcmp(tmp->name.c_str(), "publishRawData") == 0) {
       jsonDoc[F("publishRawData")] = tmp->value;
+    } else if (strcmp(tmp->name.c_str(), "listenRawData") == 0) {
+      jsonDoc[F("listenRawData")] = tmp->value;
     } else if (strcmp(tmp->name.c_str(), "optionalPCB") == 0) {
       jsonDoc[F("optionalPCB")] = tmp->value;
     } else if (strcmp(tmp->name.c_str(), "opentherm") == 0) {
@@ -704,6 +714,10 @@ int saveSettings(struct webserver_t *client, settingsStruct *heishamonSettings) 
       jsonDoc[F("s0_2_maxpulsewidth")] = tmp->value;
     }
     tmp = tmp->next;
+  }
+
+  if (jsonDoc[F("publishRawData")] == "enabled" && jsonDoc[F("listenRawData")] == "enabled") {
+    jsonDoc[F("listenRawData")] = String("disabled");
   }
 
   if (new_ota_password != NULL && strlen(new_ota_password) > 0 && current_ota_password != NULL && strlen(current_ota_password) > 0) {

--- a/HeishaMon/webfunctions.cpp
+++ b/HeishaMon/webfunctions.cpp
@@ -227,6 +227,7 @@ void loadSettings(settingsStruct *heishamonSettings) {
           heishamonSettings->logMqtt = ( jsonDoc[F("logMqtt")] == "enabled" ) ? true : false;
           heishamonSettings->logHexdump = ( jsonDoc[F("logHexdump")] == "enabled" ) ? true : false;
           heishamonSettings->logSerial1 = ( jsonDoc[F("logSerial1")] == "enabled" ) ? true : false;
+          heishamonSettings->publishRawData = ( jsonDoc[F("publishRawData")] == "enabled" ) ? true : false;
           heishamonSettings->optionalPCB = ( jsonDoc[F("optionalPCB")] == "enabled" ) ? true : false;
           heishamonSettings->opentherm = ( jsonDoc[F("opentherm")] == "enabled" ) ? true : false;
 #ifdef ESP32          
@@ -446,6 +447,11 @@ void settingsToJson(JsonDocument &jsonDoc, settingsStruct *heishamonSettings) {
   } else {
     jsonDoc[F("logSerial1")] = "disabled";
   }
+  if (heishamonSettings->publishRawData) {
+    jsonDoc[F("publishRawData")] = "enabled";
+  } else {
+    jsonDoc[F("publishRawData")] = "disabled";
+  }
   if (heishamonSettings->optionalPCB) {
     jsonDoc[F("optionalPCB")] = "enabled";
   } else {
@@ -598,6 +604,7 @@ int saveSettings(struct webserver_t *client, settingsStruct *heishamonSettings) 
   jsonDoc[F("logMqtt")] = String("disabled");
   jsonDoc[F("logHexdump")] = String("disabled");
   jsonDoc[F("logSerial1")] = String("disabled");
+  jsonDoc[F("publishRawData")] = String("disabled");
   jsonDoc[F("optionalPCB")] = String("disabled");
   jsonDoc[F("opentherm")] = String("disabled");
 
@@ -645,6 +652,8 @@ int saveSettings(struct webserver_t *client, settingsStruct *heishamonSettings) 
       jsonDoc[F("logHexdump")] = tmp->value;
     } else if (strcmp(tmp->name.c_str(), "logSerial1") == 0) {
       jsonDoc[F("logSerial1")] = tmp->value;
+    } else if (strcmp(tmp->name.c_str(), "publishRawData") == 0) {
+      jsonDoc[F("publishRawData")] = tmp->value;
     } else if (strcmp(tmp->name.c_str(), "optionalPCB") == 0) {
       jsonDoc[F("optionalPCB")] = tmp->value;
     } else if (strcmp(tmp->name.c_str(), "opentherm") == 0) {

--- a/HeishaMon/webfunctions.h
+++ b/HeishaMon/webfunctions.h
@@ -64,7 +64,8 @@ struct settingsStruct {
   bool logMqtt = false; //log to mqtt from start
   bool logHexdump = false; //log hexdump from start
   bool logSerial1 = true; //log to serial1 (gpio2) from start
-  bool publishRawData = false; //publish and receive raw heatpump mqtt debug data
+  bool publishRawData = false; //publish raw heatpump mqtt debug data
+  bool listenRawData = false; //listen to raw heatpump mqtt debug data
   bool opentherm = false; //opentherm enable flag
   bool hotspot = true; //enable wifi hotspot when wifi is not connected
 #ifdef ESP32

--- a/HeishaMon/webfunctions.h
+++ b/HeishaMon/webfunctions.h
@@ -64,6 +64,7 @@ struct settingsStruct {
   bool logMqtt = false; //log to mqtt from start
   bool logHexdump = false; //log hexdump from start
   bool logSerial1 = true; //log to serial1 (gpio2) from start
+  bool publishRawData = false; //publish and receive raw heatpump mqtt debug data
   bool opentherm = false; //opentherm enable flag
   bool hotspot = true; //enable wifi hotspot when wifi is not connected
 #ifdef ESP32


### PR DESCRIPTION
Hi!
This PR partially reverts the logic of https://github.com/heishamon/HeishaMon/commit/b32bba872e691cd0472c7b7316537f16c504952e by putting the raw data topic behind a runtime setting rather than a compile one.
This is useful when you want to get all settings at once via decoding the raw data.