### PR TITLE
Fix bc_assign_slots corrupting OP_JMP offsets for standalone event calls

### DIFF
--- a/HeishaMon/src/rules/rules.cpp
+++ b/HeishaMon/src/rules/rules.cpp
@@ -2024,6 +2024,7 @@ static void bc_assign_slots(struct rules_t *obj) {
       }
     }
     end = a;
+    start = end;
 
     for(a=end;a<getval(obj->bc.nrbytes);a = bc_next(obj, a)) {
       if(a == -1) {
@@ -2200,6 +2201,9 @@ static void bc_assign_slots(struct rules_t *obj) {
         continue;
       }
       if(gettype(obj->bc.buffer[a]) == OP_CLEAR) {
+        continue;
+      }
+      if(gettype(obj->bc.buffer[a]) == OP_CALL && getval(x->a) == 0) {
         continue;
       }
       if(d >= min) {


### PR DESCRIPTION
When a standalone call (e.g. dhw_start();) appears inside an if-block, the TSEMICOLON handler resets OP_CALL.a to 0. The segment detection in bc_assign_slots only sets `start` when it finds a node with a > 0, so with OP_CALL.a = 0 `start` stayed at 0. Loop1 then scanned from byte 0 through all preceding bytecode, corrupting OP_JMP jump offsets to -1 and breaking the if-branch entirely.

Fix 1: initialise start = end after the skip-JMPs step so that when no positive-slot node is found the loops scan only the actual segment.

Fix 2: add the same OP_CALL/a==0 continue to loop2 that loop1 already had, preventing loop2 from overwriting the no-return-value sentinel with a heap slot reference.

Fixes #894