### PR TITLE
Fix #894: reset mathcnt when a call statement closes an if-block

### DIFF
--- a/HeishaMon/src/rules/rules.cpp
+++ b/HeishaMon/src/rules/rules.cpp
@@ -3378,6 +3378,14 @@ static int16_t rule_create(char **text, struct rules_t *obj) {
                   return -1;
                   /* LCOV_EXCL_STOP*/
                 }
+                /*
+                 * A call/expression statement closes this if-block. Reset the
+                 * temporary slot counter so a following sibling if-condition
+                 * starts fresh. Otherwise mathcnt leaks across the block and
+                 * bc_parse_math_order's backward slot search overshoots into
+                 * this block, relocating its trailing logical operator (#894).
+                 */
+                mathcnt = 0;
                 go = TEND;
                 ret = TIF;
                 continue;


### PR DESCRIPTION
Two consecutive `if <cond with && or ||> then <function/event call> end` blocks compiled incorrectly: the first block's trailing OP_AND/OP_OR was relocated into the second block, so both conditions evaluated wrong and both bodies ran regardless of the condition.

The corruption is present in the parser output (before bc_assign_slots), so it is not a slot-assignment bug. Root cause: the assignment-statement path resets the temporary slot counter (mathcnt = 0) but the call/ expression-statement path does not. When a call statement closes an if-block, the leftover mathcnt makes the next sibling if-condition's first operand get a slot index != 1, so bc_parse_math_order's backward search for the start of the current expression overshoots past the previous block's call body and JMP into that block's first OP_GETVAL, pulling its trailing logical operator into the new block.

Reset mathcnt in the statement terminator's TEND branch, i.e. only when a call/expression statement is the last in its block. Doing it after every statement would change slot reuse for multi-statement bodies; scoping it to block close keeps previously-correct bytecode byte-identical.

Validated against the upstream CurlyMoo/rules unit-test suite (all 526 tests pass, no regressions) and a standalone bytecode harness covering the &&/||, multi-statement-body, nested-if and value-returning-call cases.