### PR TITLE
fix gpio mqtt call and topic memory corruption

### DIFF
--- a/HeishaMon/HeishaMon.ino
+++ b/HeishaMon/HeishaMon.ino
@@ -949,7 +949,15 @@ void mqtt_callback(char* topic, byte* payload, unsigned int length) {
       msg[i] = (char)payload[i];
     }
     msg[length] = '\0';
-    char* topic_command = topic + strlen(heishamonSettings.mqtt_topic_base) + 1; //strip base plus seperator from topic
+
+    // copy topic to the heap so a later mqtt publish can't clobber PubSubClient's buffer
+    char* topiccopy = (char*) malloc(strlen(topic) + 1);
+    if (topiccopy) {
+      memcpy(topiccopy, topic, strlen(topic) + 1);
+      topic = topiccopy;	
+    }
+	  
+	char* topic_command = topic + strlen(heishamonSettings.mqtt_topic_base) + 1; //strip base plus seperator from topic
     if (strcmp(topic_command, mqtt_send_raw_value_topic) == 0)
     { // send a raw hex string
       byte *rawcommand;
@@ -990,7 +998,8 @@ void mqtt_callback(char* topic, byte* payload, unsigned int length) {
     } else if (strncmp(topic_command, mqtt_topic_gpio, strlen(mqtt_topic_gpio)) == 0)  {
       char* topic_gpiocommand = topic_command + strlen(mqtt_topic_gpio) + 1; //strip the gpio subtopic from the topic
       mqttGPIOCallback(topic_gpiocommand, msg);
-    }    
+    } 
+    free(topiccopy);  
     mqttcallbackinprogress = false;
   }
 }

--- a/HeishaMon/gpio.cpp
+++ b/HeishaMon/gpio.cpp
@@ -12,12 +12,14 @@ void setupGPIO(gpioSettingsStruct gpioSettings) {
 }
 
 void mqttGPIOCallback(char* topic, char* value) {
-  log_message(_F("GPIO: MQTT message received"));
-#ifdef ESP32  
-  if (strcmp_P(PSTR("relay/one"), topic) == 0) {
+  char log_msg[256];
+  sprintf_P(log_msg, PSTR("GPIO: MQTT message received on subtopic '%s' value '%s'"), topic, value);
+  log_message(log_msg);
+#ifdef ESP32
+  if (strcmp_P(topic, PSTR("relay/one")) == 0) {
     log_message(_F("GPIO: MQTT message received 'relay/one'"));
     digitalWrite(relayOnePin,((stricmp((char*)"true", value) == 0) || (stricmp((char*)"on", value) == 0)  || (stricmp((char*)"enable", value) == 0)|| (String(value).toInt() == 1 )));
-  } else if (strcmp_P(PSTR("relay/two"), topic) == 0) {
+  } else if (strcmp_P(topic,PSTR("relay/two")) == 0) {
     log_message(_F("GPIO: MQTT message received 'relay/two'"));
     digitalWrite(relayTwoPin,((stricmp((char*)"true", value) == 0) || (stricmp((char*)"on", value) == 0)  || (stricmp((char*)"enable", value) == 0)|| (String(value).toInt() == 1 )));
   }


### PR DESCRIPTION
when the mqtt topic from callback was used in mqtt publish (through log_message for example) it got memory corrupted as it was still the same pointer
