### PR TITLE
Dallas sensors are now remembered and re-used after failed boot scan

### DIFF
--- a/HeishaMon/HeishaMon.ino
+++ b/HeishaMon/HeishaMon.ino
@@ -124,6 +124,11 @@ char mqtt_topic[256];
 
 static int mqttReconnects = 0;
 
+// state for restoring known 1wire sensors from mqtt retained messages just after boot
+bool dallasMqttRestorePending = false;
+unsigned long dallasMqttRestoreStart = 0;
+#define DALLAS_MQTT_RESTORE_TIMEOUT 3000
+
 // can't have too much in buffer due to memory shortage
 #define MAXCOMMANDSINBUFFER 10
 
@@ -494,6 +499,12 @@ void mqtt_reconnect()
         mqtt_client.subscribe(mqtt_topic);
         sprintf_P(mqtt_topic, PSTR("%s/%s/WatthourTotal/2"), heishamonSettings.mqtt_topic_base, mqtt_topic_s0);
         mqtt_client.subscribe(mqtt_topic);
+      }
+      if (heishamonSettings.use_1wire && mqttReconnects == 1) { // only on first connect: retrieve previously known 1wire sensors from their retained mqtt topics
+        sprintf_P(mqtt_topic, PSTR("%s/%s/+"), heishamonSettings.mqtt_topic_base, mqtt_topic_1wire);
+        mqtt_client.subscribe(mqtt_topic);
+        dallasMqttRestorePending = true;
+        dallasMqttRestoreStart = millis();
       }
       if (mqttReconnects == 1) { //only resend all data on first connect to mqtt so a data bomb like and bad mqtt server will not cause a reconnect bomb everytime
         if (heishamonSettings.use_1wire) resetlastalldatatime_dallas(); //resend all 1wire values to mqtt
@@ -998,8 +1009,13 @@ void mqtt_callback(char* topic, byte* payload, unsigned int length) {
     } else if (strncmp(topic_command, mqtt_topic_gpio, strlen(mqtt_topic_gpio)) == 0)  {
       char* topic_gpiocommand = topic_command + strlen(mqtt_topic_gpio) + 1; //strip the gpio subtopic from the topic
       mqttGPIOCallback(topic_gpiocommand, msg);
-    } 
-    free(topiccopy);  
+    } else if (strncmp(topic_command, mqtt_topic_1wire, strlen(mqtt_topic_1wire)) == 0) { //this is a 1wire address topic, restore its retained value at boot
+      char* topic_1wire_address = topic_command + strlen(mqtt_topic_1wire) + 1; //strip the "1wire/" from the topic to get the sensor address
+      if ((strchr(topic_1wire_address, '/') == NULL) && (length > 0)) { //only handle the address topic itself (not .../alias) and skip empty (cleared) retained messages
+        restoreDallasFromMqtt(topic_1wire_address, String(msg).toFloat(), log_message);
+      }
+    }
+    free(topiccopy);
     mqttcallbackinprogress = false;
   }
 }
@@ -1053,6 +1069,8 @@ int8_t webserver_cb(struct webserver_t *client, void *dat) {
           client->route = 50;
         } else if (strcmp((char *)dat, "/dallasalias") == 0) {
           client->route = 60;
+        } else if (strcmp((char *)dat, "/removedallas") == 0) {
+          client->route = 190;
         } else if (strcmp((char *)dat, "/togglelog") == 0) {
           client->route = 1;
           log_message(_F("Toggled mqtt log flag"));
@@ -1149,6 +1167,10 @@ int8_t webserver_cb(struct webserver_t *client, void *dat) {
               sprintf_P(log_msg, PSTR("Dallas alias changed address %s to alias %s"), args->name, args->value);
               log_message(log_msg);
               changeDallasAlias((char *)args->name, (char *)args->value);
+              return 0;
+            } break;
+          case 190: {
+              removeDallasSensor(mqtt_client, heishamonSettings.mqtt_topic_base, (char *)args->name, log_message);
               return 0;
             } break;
           case 100: {
@@ -1292,6 +1314,9 @@ int8_t webserver_cb(struct webserver_t *client, void *dat) {
           case 60: {
               return 0;
             } break;
+          case 190: {
+              return 0;
+            } break;
           case 80: {
               if (client->content == 0) {
                 webserver_send(client, 302, (char *)"text/html", 0);
@@ -1420,8 +1445,8 @@ int8_t webserver_cb(struct webserver_t *client, void *dat) {
 
             } break;
           case 180: {
-              if (heishamonSettings.use_1wire) initDallasSensors(log_message, heishamonSettings.updataAllDallasTime, heishamonSettings.waitDallasTime, heishamonSettings.dallasResolution);
-            } break;            
+              if (heishamonSettings.use_1wire) rescanDallasSensors(log_message, heishamonSettings.dallasResolution);
+            } break;
           default: {
               webserver_send(client, 301, (char *)"text/plain", 0);
             } break;
@@ -1436,7 +1461,8 @@ int8_t webserver_cb(struct webserver_t *client, void *dat) {
               return -1;
             } break;
           case 60:
-          case 70: {
+          case 70:
+          case 190: {
               header->ptr += sprintf_P((char *)header->buffer, PSTR("Location: /"));
               return -1;
             } break;
@@ -1998,6 +2024,13 @@ void loop() {
 #endif
 
   if (heishamonSettings.use_1wire) dallasLoop(mqtt_client, log_message, heishamonSettings.mqtt_topic_base);
+
+  if (dallasMqttRestorePending && ((unsigned long)(millis() - dallasMqttRestoreStart) > DALLAS_MQTT_RESTORE_TIMEOUT)) {
+    sprintf_P(mqtt_topic, PSTR("%s/%s/+"), heishamonSettings.mqtt_topic_base, mqtt_topic_1wire);
+    mqtt_client.unsubscribe(mqtt_topic);
+    dallasMqttRestorePending = false;
+    log_message(_F("Done restoring 1wire sensors from mqtt"));
+  }
 
   if (heishamonSettings.use_s0) s0Loop(mqtt_client, log_message, heishamonSettings.mqtt_topic_base, heishamonSettings.s0Settings);
 

--- a/HeishaMon/dallas.cpp
+++ b/HeishaMon/dallas.cpp
@@ -17,9 +17,9 @@
 OneWire oneWire(ONE_WIRE_BUS);
 DallasTemperature DS18B20(&oneWire);
 
-//global array for 1wire data
+//global array for 1wire data - fixed size so known sensors survive across rescans
 dallasDataStruct* actDallasData = 0;
-int dallasDevicecount = 0;
+int dallasDevicecount = 0; // kept as the array length (MAX_DALLAS_SENSORS) for external callers; iterate using the "known" flag
 
 
 unsigned long lastalldatatime_dallas = 0;
@@ -29,39 +29,92 @@ unsigned long dallasTimer1 = 0;
 unsigned int updateAllDallasTime = 30000; // will be set using heishmonSettings
 unsigned int dallasTimerWait = 30000; // will be set using heishmonSettings
 void loadDallasAlias();
+void saveDallasAliasFile();
 
-void initDallasSensors(void (*log_message)(char*), unsigned int updateAllDallasTimeSettings, unsigned int dallasTimerWaitSettings, unsigned int dallasResolution) {
+static int findDallasSlot(const char* address) {
+  for (int i = 0; i < MAX_DALLAS_SENSORS; i++) {
+    if (actDallasData[i].known && strcmp(actDallasData[i].address, address) == 0) return i;
+  }
+  return -1;
+}
+
+static int findFreeDallasSlot() {
+  for (int i = 0; i < MAX_DALLAS_SENSORS; i++) {
+    if (!actDallasData[i].known) return i;
+  }
+  return -1;
+}
+
+// parses a 16 hex char address string (as produced/stored in .address) back into a DeviceAddress,
+// so sensors restored purely from mqtt can still be addressed directly on the bus without a rescan
+static void parseDallasAddress(const char* addrStr, DeviceAddress out) {
+  for (int x = 0; x < 8; x++) {
+    char byteStr[3] = { addrStr[x * 2], addrStr[x * 2 + 1], '\0' };
+    out[x] = (uint8_t) strtoul(byteStr, NULL, 16);
+  }
+}
+
+void rescanDallasSensors(void (*log_message)(char*), unsigned int dallasResolution) {
   char log_msg[256];
-  updateAllDallasTime = updateAllDallasTimeSettings;
-  dallasTimerWait = dallasTimerWaitSettings;
-  DS18B20.begin();
-  dallasDevicecount  = DS18B20.getDeviceCount();
-  sprintf_P(log_msg, PSTR("Number of 1wire sensors on bus: %d"), dallasDevicecount); log_message(log_msg);
-  if ( dallasDevicecount > MAX_DALLAS_SENSORS) {
-    dallasDevicecount = MAX_DALLAS_SENSORS;
-    sprintf_P(log_msg, PSTR("Reached max 1wire sensor count. Only %d sensors will provide data."), dallasDevicecount);
-    log_message(log_msg);
+  DS18B20.begin(); // re-search the bus so newly attached sensors are actually detected
+  int found = DS18B20.getDeviceCount();
+  sprintf_P(log_msg, PSTR("Number of 1wire sensors on bus: %d"), found); log_message(log_msg);
+
+  //assume known sensors are gone until the scan below re-affirms them
+  for (int i = 0; i < MAX_DALLAS_SENSORS; i++) {
+    if (actDallasData[i].known) actDallasData[i].present = false;
   }
 
-  //init array
-  delete actDallasData;
-  actDallasData = new dallasDataStruct [dallasDevicecount];
-  for (int j = 0 ; j < dallasDevicecount; j++) {
-    DS18B20.getAddress(actDallasData[j].sensor, j);
-    DS18B20.setResolution(actDallasData[j].sensor, dallasResolution);
-  }
-
-  DS18B20.requestTemperatures();
-  for (int i = 0 ; i < dallasDevicecount; i++) {
-    actDallasData[i].address[16] = '\0';
-    for (int x = 0; x < 8; x++)  {
-      // zero pad the address if necessary
-      sprintf(&actDallasData[i].address[x * 2], "%02x", actDallasData[i].sensor[x]);
+  for (int j = 0; j < found; j++) {
+    DeviceAddress addr;
+    if (!DS18B20.getAddress(addr, j)) continue;
+    char addrStr[17];
+    addrStr[16] = '\0';
+    for (int x = 0; x < 8; x++) {
+      sprintf(&addrStr[x * 2], "%02x", addr[x]);
     }
-    sprintf_P(log_msg, PSTR("Found 1wire sensor: %s"), actDallasData[i].address ); log_message(log_msg);
+
+    int slot = findDallasSlot(addrStr);
+    if (slot < 0) {
+      slot = findFreeDallasSlot();
+      if (slot < 0) {
+        sprintf_P(log_msg, PSTR("Reached max 1wire sensor count (%d). Ignoring sensor: %s"), MAX_DALLAS_SENSORS, addrStr);
+        log_message(log_msg);
+        continue;
+      }
+      actDallasData[slot].known = true;
+      strlcpy(actDallasData[slot].address, addrStr, sizeof(actDallasData[slot].address));
+      actDallasData[slot].temperature = -127.0;
+      actDallasData[slot].lastgoodtime = 0;
+      strlcpy(actDallasData[slot].alias, "NOT SET", sizeof(actDallasData[slot].alias));
+      sprintf_P(log_msg, PSTR("Found new 1wire sensor: %s"), addrStr); log_message(log_msg);
+      sprintf_P(log_msg, PSTR("{\"data\": {\"dallasRescan\": true}}")); websocket_write_all(log_msg, strlen(log_msg)); // tell open browser tabs to reload the sensor table
+    }
+    memcpy(actDallasData[slot].sensor, addr, sizeof(DeviceAddress));
+    actDallasData[slot].present = true;
+    DS18B20.setResolution(addr, dallasResolution);
   }
+
+  for (int i = 0; i < MAX_DALLAS_SENSORS; i++) {
+    if (actDallasData[i].known && !actDallasData[i].present) {
+      sprintf_P(log_msg, PSTR("Known 1wire sensor not responding: %s"), actDallasData[i].address); log_message(log_msg);
+    }
+  }
+
   if (DALLASASYNC) DS18B20.setWaitForConversion(false); //async 1wire during next loops
   loadDallasAlias();
+}
+
+void initDallasSensors(void (*log_message)(char*), unsigned int updateAllDallasTimeSettings, unsigned int dallasTimerWaitSettings, unsigned int dallasResolution) {
+  updateAllDallasTime = updateAllDallasTimeSettings;
+  dallasTimerWait = dallasTimerWaitSettings;
+
+  if (!actDallasData) {
+    actDallasData = new dallasDataStruct [MAX_DALLAS_SENSORS];
+    dallasDevicecount = MAX_DALLAS_SENSORS;
+  }
+
+  rescanDallasSensors(log_message, dallasResolution);
 }
 
 void resetlastalldatatime_dallas() {
@@ -80,12 +133,28 @@ void readNewDallasTemp(PubSubClient &mqtt_client, void (*log_message)(char*), ch
   }
   if (!(DALLASASYNC)) DS18B20.requestTemperatures();
   for (int i = 0; i < dallasDevicecount; i++) {
+    if (!actDallasData[i].known) continue; // query every known sensor, even ones currently marked offline, so they can be marked online again once they respond
     float temp = DS18B20.getTempC(actDallasData[i].sensor);
+    bool wasPresent = actDallasData[i].present;
     if (temp < -120.0) {
-      sprintf_P(log_msg, PSTR("Error 1wire sensor offline: %s"), actDallasData[i].address); log_message(log_msg);
+      actDallasData[i].present = false;
+      if (wasPresent) {
+        sprintf_P(log_msg, PSTR("1wire sensor went offline: %s"), actDallasData[i].address); log_message(log_msg);
+        sprintf_P(log_msg, PSTR("{\"data\": {\"dallasvalues\": {\"sensorID\": \"%s\", \"present\": false}}}"), actDallasData[i].address);
+        websocket_write_all(log_msg, strlen(log_msg));
+      }
     } else {
+      actDallasData[i].present = true;
+      if (!wasPresent) {
+        sprintf_P(log_msg, PSTR("1wire sensor back online: %s"), actDallasData[i].address); log_message(log_msg);
+        sprintf_P(log_msg, PSTR("{\"data\": {\"dallasvalues\": {\"sensorID\": \"%s\", \"present\": true}}}"), actDallasData[i].address);
+        websocket_write_all(log_msg, strlen(log_msg));
+      }
       float allowedtempdiff = (((millis() - actDallasData[i].lastgoodtime)) / 1000.0) * MAXTEMPDIFFPERSEC;
-      if ((actDallasData[i].temperature != -127.0) and ((temp > (actDallasData[i].temperature + allowedtempdiff)) or (temp < (actDallasData[i].temperature - allowedtempdiff)))) {
+      if (fabs(temp - 85.0) < 0.0001) { // 85.0C is the DS18B20 power-on reset default, not a real reading; sensor is online, just not converted yet
+        sprintf_P(log_msg, PSTR("Ignoring 1wire sensor power-on-reset value (85.00): %s"), actDallasData[i].address);
+        log_message(log_msg);
+      } else if ((actDallasData[i].temperature != -127.0) and ((temp > (actDallasData[i].temperature + allowedtempdiff)) or (temp < (actDallasData[i].temperature - allowedtempdiff)))) {
         sprintf_P(log_msg, PSTR("Filtering 1wire sensor temperature (%s). Delta to high. Current: %.2f Last: %.2f"), actDallasData[i].address, temp, actDallasData[i].temperature);
         log_message(log_msg);
       } else {
@@ -132,7 +201,11 @@ void dallasLoop(PubSubClient &mqtt_client, void (*log_message)(char*), char* mqt
 void dallasJsonOutput(struct webserver_t *client) {
   webserver_send_content_P(client, PSTR("["), 1);
 
+  bool first = true;
   for (int i = 0; i < dallasDevicecount; i++) {
+    if (!actDallasData[i].known) continue;
+    if (!first) webserver_send_content_P(client, PSTR(","), 1);
+    first = false;
     webserver_send_content_P(client, PSTR("{\"Sensor\":\""), 11);
     webserver_send_content(client, actDallasData[i].address, strlen(actDallasData[i].address));
     webserver_send_content_P(client, PSTR("\",\"Temperature\":"), 16);
@@ -141,21 +214,25 @@ void dallasJsonOutput(struct webserver_t *client) {
     webserver_send_content(client, str, strlen(str));
     webserver_send_content_P(client, PSTR(",\"Alias\":\""), 10);
     webserver_send_content(client, actDallasData[i].alias, strlen(actDallasData[i].alias));
-    if (i < dallasDevicecount - 1) {
-      webserver_send_content_P(client, PSTR("\"},"), 3);
+    webserver_send_content_P(client, PSTR("\",\"Present\":"), 12);
+    if (actDallasData[i].present) {
+      webserver_send_content_P(client, PSTR("true"), 4);
     } else {
-      webserver_send_content_P(client, PSTR("\"}"), 2);
+      webserver_send_content_P(client, PSTR("false"), 5);
     }
+    webserver_send_content_P(client, PSTR(",\"LastSeenSeconds\":"), 19);
+    long lastSeenSeconds = (actDallasData[i].lastgoodtime == 0) ? -1 : (long)((millis() - actDallasData[i].lastgoodtime) / 1000);
+    sprintf(str, "%ld", lastSeenSeconds);
+    webserver_send_content(client, str, strlen(str));
+    webserver_send_content_P(client, PSTR("}"), 1);
   }
   webserver_send_content_P(client, PSTR("]"), 1);
 }
 
-void changeDallasAlias(char* address, char* alias) {
+void saveDallasAliasFile() {
   JsonDocument jsonDoc;
   for (int i = 0 ; i < dallasDevicecount; i++) {
-    if (strcmp(address, actDallasData[i].address) == 0) {
-      strlcpy(actDallasData[i].alias, alias, sizeof(actDallasData[i].alias));
-    }
+    if (!actDallasData[i].known) continue;
     jsonDoc[actDallasData[i].address] = actDallasData[i].alias;
   }
   if (LittleFS.begin()) {
@@ -164,6 +241,50 @@ void changeDallasAlias(char* address, char* alias) {
       serializeJson(jsonDoc, configFile);
       configFile.close();
     }
+  }
+}
+
+void changeDallasAlias(char* address, char* alias) {
+  int slot = findDallasSlot(address);
+  if (slot < 0) return;
+  strlcpy(actDallasData[slot].alias, alias, sizeof(actDallasData[slot].alias));
+  saveDallasAliasFile();
+}
+
+void removeDallasSensor(PubSubClient &mqtt_client, char* mqtt_topic_base, char* address, void (*log_message)(char*)) {
+  char log_msg[256];
+  int slot = findDallasSlot(address);
+  if (slot < 0) return;
+
+  char mqtt_topic[256];
+  // publishing an empty retained payload clears the previously retained message on the broker
+  sprintf_P(mqtt_topic, PSTR("%s/%s/%s"), mqtt_topic_base, mqtt_topic_1wire, address); mqtt_client.publish(mqtt_topic, "", true);
+  sprintf_P(mqtt_topic, PSTR("%s/%s/%s/alias"), mqtt_topic_base, mqtt_topic_1wire, address); mqtt_client.publish(mqtt_topic, "", true);
+
+  sprintf_P(log_msg, PSTR("Removed 1wire sensor: %s"), address); log_message(log_msg);
+
+  actDallasData[slot] = dallasDataStruct();
+  saveDallasAliasFile();
+  sprintf_P(log_msg, PSTR("{\"data\": {\"dallasRescan\": true}}")); websocket_write_all(log_msg, strlen(log_msg)); // tell open browser tabs to reload the sensor table
+}
+
+void restoreDallasFromMqtt(char* address, float temperature, void (*log_message)(char*)) {
+  char log_msg[256];
+  int slot = findDallasSlot(address);
+  if (slot < 0) {
+    slot = findFreeDallasSlot();
+    if (slot < 0) return; //no room left, ignore
+    actDallasData[slot].known = true;
+    actDallasData[slot].present = false;
+    strlcpy(actDallasData[slot].address, address, sizeof(actDallasData[slot].address));
+    if (strlen(address) == 16) parseDallasAddress(address, actDallasData[slot].sensor); // allows this sensor to be polled directly without waiting for a bus rescan
+    strlcpy(actDallasData[slot].alias, "NOT SET", sizeof(actDallasData[slot].alias));
+    sprintf_P(log_msg, PSTR("Restored previously known 1wire sensor from mqtt: %s"), address); log_message(log_msg);
+    loadDallasAlias();
+    sprintf_P(log_msg, PSTR("{\"data\": {\"dallasRescan\": true}}")); websocket_write_all(log_msg, strlen(log_msg)); // tell open browser tabs to reload the sensor table
+  }
+  if (actDallasData[slot].lastgoodtime == 0) { //only backfill if we haven't taken a real reading yet this boot
+    actDallasData[slot].temperature = temperature;
   }
 }
 
@@ -179,6 +300,7 @@ void loadDallasAlias() {
         DeserializationError error = deserializeJson(jsonDoc, buf.get());
         if (!error) {
           for (int i = 0 ; i < dallasDevicecount; i++) {
+            if (!actDallasData[i].known) continue;
             if ( jsonDoc[actDallasData[i].address] ) strncpy(actDallasData[i].alias, jsonDoc[actDallasData[i].address], sizeof(actDallasData[i].alias));
           }
         }

--- a/HeishaMon/dallas.h
+++ b/HeishaMon/dallas.h
@@ -16,15 +16,20 @@
 struct dallasDataStruct {
   float temperature = -127.0;
   unsigned long lastgoodtime = 0;
+  bool known = false;   // slot is in use (sensor has been seen on the bus and/or restored from mqtt)
+  bool present = false; // sensor was found on the 1-wire bus during the last scan
   DeviceAddress sensor;
-  char address[17];
+  char address[17] = "";
   char alias[32] = "NOT SET";
 };
 
 void resetlastalldatatime_dallas();
 void dallasLoop(PubSubClient &mqtt_client, void (*log_message)(char*), char* mqtt_topic_base);
 void initDallasSensors(void (*log_message)(char*), unsigned int updataAllDallasTimeSettings, unsigned int dallasTimerWaitSettings, unsigned int dallasResolution);
+void rescanDallasSensors(void (*log_message)(char*), unsigned int dallasResolution);
 void dallasJsonOutput(struct webserver_t *client);
 void changeDallasAlias(char* address, char* alias);
+void removeDallasSensor(PubSubClient &mqtt_client, char* mqtt_topic_base, char* address, void (*log_message)(char*));
+void restoreDallasFromMqtt(char* address, float temperature, void (*log_message)(char*));
 
 #endif

--- a/HeishaMon/htmlcode.h
+++ b/HeishaMon/htmlcode.h
@@ -870,13 +870,17 @@ function startWebsockets(){
             updCell(j.data.heishavalues.topic+'-Value',j.data.heishavalues.value);
             updCell(j.data.heishavalues.topic+'-Description',j.data.heishavalues.description);
           } else if(j.data.dallasvalues){
-            updCell('SensorID-'+j.data.dallasvalues.sensorID+'-Temperature',j.data.dallasvalues.value);
+            var dID=j.data.dallasvalues.sensorID;
+            if(j.data.dallasvalues.value!==undefined)updCell('SensorID-'+dID+'-Temperature',j.data.dallasvalues.value);
+            if(j.data.dallasvalues.present!==undefined)updDallasPresence(dID,j.data.dallasvalues.present);
           } else if(j.data.s0values){
             updCell('s0port-'+j.data.s0values.s0port+'-Watt',j.data.s0values.Watt);
             updCell('s0port-'+j.data.s0values.s0port+'-Watthour',j.data.s0values.Watthour);
             updCell('s0port-'+j.data.s0values.s0port+'-WatthourTotal',j.data.s0values.WatthourTotal);
           } else if(j.data.opentherm){
             updCell(j.data.opentherm.name+'-value',j.data.opentherm.value);
+          } else if(j.data.dallasRescan){
+            refreshDallasTable();
           }
         }
       } else {
@@ -950,6 +954,40 @@ function updCell(id,val){
     el.classList.add('update-effect');
   }
 }
+
+function updDallasPresence(sID,present){
+  var statusCell=document.getElementById('SensorID-'+sID+'-Status');
+  if(!statusCell)return;
+  var row=statusCell.parentElement;
+  if(row)row.style.opacity=present?'':'0.6';
+  statusCell.style.color=present?'':'var(--danger,#f44336)';
+  if(present){
+    delete statusCell.dataset.offlineSince;
+    statusCell.classList.remove('offline-duration');
+    statusCell.textContent='OK';
+  } else {
+    statusCell.dataset.offlineSince=Date.now();
+    statusCell.classList.add('offline-duration');
+    statusCell.textContent=formatOfflineDuration(false,0);
+  }
+}
+
+function formatOfflineDuration(present,lastSeenSeconds){
+  if(present)return'OK';
+  if(lastSeenSeconds==null||lastSeenSeconds<0)return'Offline (never seen)';
+  var s=lastSeenSeconds;
+  if(s<60)return'Offline for '+s+'s';
+  if(s<3600)return'Offline for '+Math.floor(s/60)+'m';
+  if(s<86400)return'Offline for '+Math.floor(s/3600)+'h';
+  return'Offline for '+Math.floor(s/86400)+'d';
+}
+
+setInterval(function(){
+  document.querySelectorAll('.offline-duration[data-offline-since]').forEach(function(cell){
+    var seconds=Math.floor((Date.now()-cell.dataset.offlineSince)/1000);
+    cell.textContent=formatOfflineDuration(false,seconds);
+  });
+},15000);
 </script>
 )====";
 
@@ -987,6 +1025,69 @@ var dallasAliasEdit=function(){
   xhr.open('GET','/dallasalias?'+addr+'='+alias,true);
   xhr.send();
 };
+function rescanDallas(){
+  var xhr=new XMLHttpRequest();
+  xhr.open('GET','/scandallas',true);
+  xhr.onload=function(){refreshTable();};
+  xhr.send();
+}
+function removeDallas(addr){
+  if(!confirm('Remove sensor '+addr+'? This also clears its retained mqtt value.'))return;
+  var xhr=new XMLHttpRequest();
+  xhr.open('GET','/removedallas?'+addr+'=1',true);
+  xhr.onload=function(){refreshTable();};
+  xhr.send();
+}
+function renderDallasTable(d){
+  if(!(d&&d['1wire']&&Array.isArray(d['1wire'])))return;
+  var tb=document.getElementById('dallasvalues');tb.innerHTML='';
+  d['1wire'].forEach(function(item){
+    var row=document.createElement('tr');
+    var sID=item['Sensor'];
+    if(!item.Present)row.style.opacity='0.6';
+    ['Sensor','Temperature','Alias'].forEach(function(k){
+      var cell=document.createElement('td');
+      cell.id='SensorID-'+sID+'-'+k;
+      if(k==='Alias'){
+        var div=document.createElement('div');
+        div.textContent=item[k];
+        div.classList.add('alias-edit');
+        div.contentEditable='true';
+        div.setAttribute('data-address',item.Sensor);
+        div.addEventListener('focus',function(){isEditing=true;});
+        div.addEventListener('blur',dallasAliasEdit);
+        cell.appendChild(div);
+      } else {cell.textContent=item[k];}
+      row.appendChild(cell);
+    });
+    var statusCell=document.createElement('td');
+    statusCell.id='SensorID-'+sID+'-Status';
+    if(!item.Present){
+      statusCell.style.color='var(--danger,#f44336)';
+      statusCell.classList.add('offline-duration');
+      if(item.LastSeenSeconds>=0)statusCell.dataset.offlineSince=Date.now()-item.LastSeenSeconds*1000;
+    }
+    statusCell.textContent=formatOfflineDuration(item.Present,item.LastSeenSeconds);
+    row.appendChild(statusCell);
+    var actionCell=document.createElement('td');
+    var removeBtn=document.createElement('button');
+    removeBtn.textContent='Remove';
+    removeBtn.className='btn btn-ghost';
+    removeBtn.style.cssText='padding:2px 8px;font-size:11px;height:22px;';
+    removeBtn.onclick=function(){removeDallas(sID);};
+    actionCell.appendChild(removeBtn);
+    row.appendChild(actionCell);
+    tb.appendChild(row);
+  });
+}
+async function refreshDallasTable(){
+  try{
+    if(isEditing)return;
+    var res=await fetch('/json');
+    var d=await res.json();
+    renderDallasTable(d);
+  }catch(e){}
+}
 async function refreshTable(){
   try{
     if(isEditing)return;
@@ -1004,29 +1105,7 @@ async function refreshTable(){
       var tb=document.getElementById('heishavalues');
       d['heatpump optional'].forEach(function(item){tb.appendChild(buildRow(item,'Topic'));});
     }
-    if(d&&d['1wire']&&Array.isArray(d['1wire'])){
-      var tb=document.getElementById('dallasvalues');tb.innerHTML='';
-      d['1wire'].forEach(function(item){
-        var row=document.createElement('tr');
-        var sID=item['Sensor'];
-        for(var k in item){if(Object.hasOwn(item,k)){
-          var cell=document.createElement('td');
-          cell.id='SensorID-'+sID+'-'+k;
-          if(k==='Alias'){
-            var div=document.createElement('div');
-            div.textContent=item[k];
-            div.classList.add('alias-edit');
-            div.contentEditable='true';
-            div.setAttribute('data-address',item.Sensor);
-            div.addEventListener('focus',function(){isEditing=true;});
-            div.addEventListener('blur',dallasAliasEdit);
-            cell.appendChild(div);
-          } else {cell.textContent=item[k];}
-          row.appendChild(cell);
-        }}
-        tb.appendChild(row);
-      });
-    }
+    renderDallasTable(d);
     if(d&&d.s0&&Array.isArray(d.s0)){
       var tb=document.getElementById('s0values');tb.innerHTML='';
       d.s0.forEach(function(item){
@@ -1228,11 +1307,11 @@ static const char webBodyRootHeatpumpValues[] FLASHPROG = R"====(
 static const char webBodyRootDallasValues[] FLASHPROG = R"====(
 <div id='Dallas' class='tab-pane'>
 <div class='panel'>
-  <div class='panel-header'><h3>Dallas 1-Wire Sensors</h3><span class='panel-meta'>Live</span></div>
+  <div class='panel-header'><h3>Dallas 1-Wire Sensors</h3><button onclick='rescanDallas()' class='btn btn-ghost' style='padding:4px 10px;font-size:11px;height:24px;'>&#8635; Rescan bus</button></div>
   <table><thead><tr>
-    <th>Sensor</th><th>Temperature</th><th>Alias</th>
+    <th>Sensor</th><th>Temperature</th><th>Alias</th><th>Status</th><th></th>
   </tr></thead><tbody id='dallasvalues'>
-    <tr><td colspan='3' style='color:var(--text-muted);padding:24px;text-align:center'>Loading…</td></tr>
+    <tr><td colspan='5' style='color:var(--text-muted);padding:24px;text-align:center'>Loading…</td></tr>
   </tbody></table>
 </div></div>
 )====";


### PR DESCRIPTION
 Improves reliability and usability of the 1-Wire sensor handling:

  - Sensors survive rescans: known sensors are now kept in fixed slots instead of being wiped whenever the bus is rescanned, so a momentarily offline sensor doesn't disappear.
  - Offline sensors are retried: previously offline sensors are now polled every cycle (not skipped), so they're automatically marked back online as soon as they respond — no manual rescan
  or reboot needed.
  - MQTT restore on boot: on first MQTT connect, previously-known sensors are restored from their retained topics so temperatures aren't blank after a reboot.
  - Manual remove: new "Remove" button per sensor (clears its retained MQTT topics too).
  - Live UI updates: the Dallas table now updates itself over the websocket when a sensor goes offline/online or a new one is discovered — no page reload needed.
  - Status column: shows "OK" or "Offline for Xm/Xh/Xd" per sensor at a glance.
  - Ignore power-on-reset reads: filters out the DS18B20's spurious 85.00°C default value instead of reporting it as a real reading.
