### PR TITLE
Print local variables of all rule blocks in console debug dump

### DIFF
--- a/HeishaMon/rules.cpp
+++ b/HeishaMon/rules.cpp
@@ -859,6 +859,17 @@ static void rules_print_stack(struct varstack_t *table) {
   }
 }
 
+static void rules_print_local_stacks(void) {
+  uint8_t x = 0;
+  for(x = 0; x < nrrules; x++) {
+    struct varstack_t *node = (struct varstack_t *)rules[x]->userdata;
+    if(node != NULL && node->nr > 0) {
+      logprintf_P(F("\n>>> local variables (%s)\n"), rules[x]->name);
+      rules_print_stack(node);
+    }
+  }
+}
+
 void rules_timer_cb(int nr) {
   char *name = NULL;
   int x = 0, i = 0;
@@ -885,8 +896,7 @@ void rules_timer_cb(int nr) {
     if(ret == 0) {
       logprintf_P(F("%s%d %s %d %s"), F("rule #"), rules[nr]->nr, F("was executed in"), timestamp.second - timestamp.first, F("microseconds"));
 
-      logprintf_P(F("\n>>> local variables\n"));
-      rules_print_stack((struct varstack_t *)rules[nr]->userdata);
+      rules_print_local_stacks();
       logprintf_P(F("\n>>> global variables\n"));
       rules_print_stack(&global_varstack);
       rules_free_stack();
@@ -1039,8 +1049,7 @@ void rules_event_cb(const char *prefix, const char *name) {
     if(ret == 0) {
       logprintf_P(F("%s%d %s %d %s"), F("rule #"), rules[nr]->nr, F("was executed in"), timestamp.second - timestamp.first, F("microseconds"));
 
-      logprintf_P(F("\n>>> local variables\n"));
-      rules_print_stack((struct varstack_t *)rules[nr]->userdata);
+      rules_print_local_stacks();
       logprintf_P(F("\n>>> global variables\n"));
       rules_print_stack(&global_varstack);
       rules_free_stack();
@@ -1064,8 +1073,7 @@ void rules_boot(void) {
     if(ret == 0) {
       logprintf_P(F("%s%d %s %d %s"), F("rule #"), rules[nr]->nr, F("was executed in"), timestamp.second - timestamp.first, F("microseconds"));
 
-      logprintf_P(F("\n>>> local variables\n"));
-      rules_print_stack((struct varstack_t *)rules[nr]->userdata);
+      rules_print_local_stacks();
       logprintf_P(F("\n>>> global variables\n"));
       rules_print_stack(&global_varstack);
       rules_free_stack();


### PR DESCRIPTION
## Problem

The rules-engine console dump after each firing only printed the local variable stack of the block that **triggered** the firing (`rules[nr]->userdata`). Local `$` variables of blocks invoked as functions — e.g. a `throttle()` helper called from an `on @Main_Outlet_Temp` handler — live in the called block's own local stack and were never printed. In practice only `#` globals were visible in the console when the actual logic runs inside a function block, which makes rulesets that use function-local scratch variables impossible to debug from the console.

## Fix

Add `rules_print_local_stacks()`, which walks all rule blocks and prints every non-empty local stack labeled with its block name, and call it from the three dump sites (`rules_timer_cb`, `rules_event_cb`, `rules_boot`) in place of the single-block print.

This is safe because every populated local stack belongs to the current firing: `rules_free_stack()` frees all of them immediately after the dump, so nothing stale can appear.

Console output now looks like:

```
>>> local variables (throttle)
 0 $newQuietMode = 1
 1 $roomDelta = 0
 2 $outletDeltaHeat = 1.19995
 3 $newHeatRequest = 0

>>> global variables
 ...
```

Nested firings that pass through several function blocks show each block's locals, attributed to the block they belong to.

## Verification

- Reproduced the issue off-device with a host harness around the unmodified rules engine (`src/rules/`): after an `on @Main_Outlet_Temp` firing that calls `throttle()`, the trigger block's local stack is empty while the throttle block's stack holds the `$` values — confirming they existed but were never printed.
- The new helper's iterate-all-blocks logic was validated in the same harness and surfaces the called block's locals correctly.
- The helper as written compile-checks cleanly against the real `rules.h` structs (`g++ -Wall`). `logprintf_P(F("…%s…"), name)` with a RAM string argument follows the existing pattern in this file, and `rules[x]->name` is already dereferenced directly on-device by `rule_by_name`.
- Full firmware build is left to CI (no local Arduino toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)