### PR TITLE
Add heat pump model WH-SXC09H3E5 / WH-UX09HE5 (T-CAP 9kW 1ph)

### DIFF
--- a/HeatPumpType.md
+++ b/HeatPumpType.md
@@ -77,6 +77,7 @@ Assuming that bytes from #129 to #138 are unique for each model of Aquarea heat 
 |70 | E2 CF 0B 84 05 12 D0 0B 93 05 | WH-SQC16H9E8 | WH-UQ16HE8 | KIT-WQC16H9E8 | 16 | 3ph | T-CAP - Bi-bloc H Serie |
 |71 | E2 D5 0B 35 99 83 92 0D 29 98 | WH-SDC0509L6E5 | WH-WDG09LE5 | KIT-WC09L6E5 | 9 | 1 ph | HP - split L-series 6kW elec heating |
 |72 | 12 D7 0B 98 14 35 94 0D 83 10 | WH-SDC0316M9E8 | WH-WXG09ME8 | Monoblock | 9 | 3ph | T-CAP - M-series  |
+|73 | E2 CF 0C 77 09 12 D0 0B 05 11 | WH-SXC09H3E5 | WH-UX09HE5 | KIT-WXC09H3E5 | 9 | 1ph | T-CAP |
 
 All bytes are used for Heat Pump model identification in the code.
 


### PR DESCRIPTION
Adds a new HeatPumpType entry (value 73) for the WH-SXC09H3E5 indoor unit
with WH-UX09HE5 outdoor unit (KIT-WXC09H3E5), a 9 kW single-phase T-CAP split.

Model bytes (129–138) captured via /debug on firmware, verified against a
clean data frame:

    E2 CF 0C 77 09 12 D0 0B 05 11

This is one byte off from the existing value 2 entry (same IDU/ODU/KIT),
differing only at byte 131 (0C vs 0D) — evidently a production-run variation,
similar to how values 2 and 49 already differ only at byte 136.

Previously reported as TOP92 = 255 (Unknown).