### PR TITLE
Add SetForceHeater command (SET47) for force/emergency heater mode

### DIFF
--- a/HeishaMon/commands.cpp
+++ b/HeishaMon/commands.cpp
@@ -336,6 +336,29 @@ unsigned int set_force_sterilization(char *msg, unsigned char *cmd, char *log_ms
   return sizeof(panasonicSendQuery);
 }
 
+unsigned int set_force_heater(char *msg, unsigned char *cmd, char *log_msg) {
+
+  String set_force_heater_string(msg);
+
+  byte force_heater_mode = 4; //hex 0x04
+  if ( set_force_heater_string.toInt() == 1 ) {
+    force_heater_mode = 8; //hex 0x08
+  }
+
+  {
+    char tmp[256] = { 0 };
+    snprintf_P(tmp, 255, PSTR("set force heater mode to %d"), (force_heater_mode / 4) - 1);
+    memcpy(log_msg, tmp, sizeof(tmp));
+  }
+
+  {
+    memcpy_P(cmd, panasonicSendQuery, sizeof(panasonicSendQuery));
+    cmd[5] = force_heater_mode;
+  }
+
+  return sizeof(panasonicSendQuery);
+}
+
 unsigned int set_holiday_mode(char *msg, unsigned char *cmd, char *log_msg) {
 
   String set_holiday_string(msg);

--- a/HeishaMon/commands.h
+++ b/HeishaMon/commands.h
@@ -40,6 +40,7 @@ unsigned int set_z2_cool_request_temperature(char *msg, unsigned char *cmd, char
 unsigned int set_force_DHW(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_force_defrost(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_force_sterilization(char *msg, unsigned char *cmd, char *log_msg);
+unsigned int set_force_heater(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_holiday_mode(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_powerful_mode(char *msg, unsigned char *cmd, char *log_msg);
 unsigned int set_operation_mode(char *msg, unsigned char *cmd, char *log_msg);
@@ -121,6 +122,8 @@ const cmdStruct commands[] PROGMEM = {
   { "SetForceDefrost", set_force_defrost },
   // set mode to force sterilization by sending 1
   { "SetForceSterilization", set_force_sterilization },
+  // set mode to force heater (emergency heating) by sending 1, off will be 0
+  { "SetForceHeater", set_force_heater },
   // set Holiday mode by sending 1, off will be 0
   { "SetHolidayMode", set_holiday_mode },
   // set Powerful mode by sending 0 = off, 1 for 30min, 2 for 60min, 3 for 90 min

--- a/MQTT-Topics.md
+++ b/MQTT-Topics.md
@@ -235,6 +235,7 @@ SET43 | SetDHWSensorSelection | Set DHW tank sensor selection (K/L series All-In
 SET44 | SetDHWHeaterState | Allow DHW backup/booster heater | 0=blocked, 1=free
 SET45 | SetRoomHeaterState | Allow Room backup/booster heater | 0=blocked, 1=free
 SET46 | SetHeaterOnOutdoorTemp | Outdoor temperature for heater ON | -15 to 20
+SET47 | SetForceHeater | Force heater mode (emergency heating), same as the heater button on the remote. State is reported in TOP68 | 0=off, 1=on
 
 
 *If you operate your heatpump in water mode with direct temperature setup: topics ending xxxRequestTemperature will set the absolute target temperature.*


### PR DESCRIPTION
## Summary

Adds a new command `SetForceHeater` (SET47) that switches the force heater (emergency heating) mode on/off — the same function as the heater button on the remote controller. It is usable from the MQTT `commands/SetForceHeater` topic and from the rules engine as `@SetForceHeater = 0/1`, and documented in `MQTT-Topics.md`.

## Protocol encoding

The response reports force heater state in TOP68 `Force_Heater_State` (byte 5, bits 5–6, `b01`=off / `b10`=on) — see the packet dumps in #918. Every existing command writes the same byte/bit position in the send query as the response reports it (`SetForceDHW`: byte 4 `0x40/0x80`, `SetHolidayMode`: byte 5 `0x10/0x20`, `SetHeatpump`: byte 4 `1/2`), so this command sends byte 5 = `0x04` (off) / `0x08` (on).

## Testing

- Tested on real hardware (ESP8266 small PCB, J-series / Jeisha): toggling via a rule sets and clears the mode, TOP68 follows, and the state change also shows on the remote room controller.
- `Examples/Rules/run_tests.sh` passes (21/21); the harness regenerates its valid-name table from `commands.h`, so `@SetForceHeater` is parse-validated in rulesets.

References #918.

🤖 Generated with [Claude Code](https://claude.com/claude-code)