### PR TITLE
Fix ESP32 SNTP setup and unpin ESP32 core version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,15 +55,10 @@ jobs:
         run: |
           arduino-cli core update-index
           arduino-cli core install esp8266:esp8266
-          arduino-cli core install esp32:esp32@3.0.7
+          arduino-cli core install esp32:esp32
 
       - name: Install dependencies
         run: arduino-cli lib install ringbuffer pubsubclient arduinojson dallastemperature onewire "Adafruit NeoPixel"
-
-      - name: Fix Onewire lib for ESP32-3.0.0
-        run: |
-          sed -i '/#include <driver\/rtc_io\.h>/a\ #include <soc\/gpio_struct\.h>' \
-            /home/runner/Arduino/libraries/OneWire/util/OneWire_direct_gpio.h
 
       - name: Compile Sketch for ESP8266
         run: cd HeishaMon && arduino-cli compile --output-dir . --fqbn=esp8266:esp8266:d1_mini:xtal=160,vt=flash,ssl=basic,mmu=3216,non32xfer=fast,eesz=4M2M,ip=lm2f,dbg=Disabled,lvl=None____,wipe=none,baud=921600 --warnings=none --verbose HeishaMon.ino

--- a/HeishaMon/HeishaMon.ino
+++ b/HeishaMon/HeishaMon.ino
@@ -1863,9 +1863,13 @@ void setup() {
   setupHttp();
 
   loggingSerial.println(F("Setup SNTP..."));
+#if defined(ESP8266)
   sntp_stop();
   sntp_setoperatingmode(SNTP_OPMODE_POLL);
   sntp_init();
+#else
+  loggingSerial.println(F("SNTP setup deferred until network is up"));
+#endif
 
   loggingSerial.println(F("Setup MQTT..."));
   setupMqtt();

--- a/HeishaMon/webfunctions.cpp
+++ b/HeishaMon/webfunctions.cpp
@@ -131,14 +131,38 @@ void ntp_dns_found(const char *name, const ip4_addr *addr, void *arg) {
 }
 #elif defined(ESP32)
 void ntp_dns_found(const char *name, const ip_addr_t *addr, void *arg) {
-  sntp_stop();
+  // ESP32 core 3.x may assert if sntp_stop is called without the TCPIP core lock.
+  // Keep this callback minimal; ESP32 uses configTzTime in ntpReload instead.
   sntp_setserver(ntpservers++, addr);
-  sntp_init();
 }
 #endif
 
 
 void ntpReload(settingsStruct *heishamonSettings) {
+#if defined(ESP32)
+  tzStruct tzCfg;
+  memcpy_P(&tzCfg, &tzdata[heishamonSettings->timezone], sizeof(tzCfg));
+  setenv("TZ", tzCfg.value, 1);
+  tzset();
+
+  char ntpList[sizeof(heishamonSettings->ntp_servers)];
+  strlcpy(ntpList, heishamonSettings->ntp_servers, sizeof(ntpList));
+  char *servers[3] = { NULL, NULL, NULL };
+  uint8_t count = 0;
+  char *token = strtok(ntpList, ",");
+  while (token != NULL && count < 3) {
+    while (*token == ' ') token++;
+    if (*token != '\0') servers[count++] = token;
+    token = strtok(NULL, ",");
+  }
+
+  if (count == 0) configTzTime(tzCfg.value, "pool.ntp.org");
+  else if (count == 1) configTzTime(tzCfg.value, servers[0]);
+  else if (count == 2) configTzTime(tzCfg.value, servers[0], servers[1]);
+  else configTzTime(tzCfg.value, servers[0], servers[1], servers[2]);
+  return;
+#endif
+
   ip_addr_t addr;
   uint8_t len = strlen(heishamonSettings->ntp_servers);
   uint8_t ptr = 0, i = 0;


### PR DESCRIPTION
Arduino-ESP32 core 3.x can assert if sntp_stop()/sntp_init() are called without holding the TCPIP core lock, which happens both at boot and from the async DNS callback. On ESP32, defer SNTP setup until the network is up and use configTzTime() in ntpReload() instead of the raw lwIP sntp_* calls, which handles locking internally. ESP8266 behavior is unchanged.

Also unpin the ESP32 core from 3.0.7 in CI and drop the OneWire GPIO header workaround, which is no longer needed since the current OneWire release (2.3.8) already includes it.