### PR TITLE
Fix rules mempool OOM crash and align buffer offsets for ESP32

### DIFF
--- a/HeishaMon/rules.cpp
+++ b/HeishaMon/rules.cpp
@@ -902,13 +902,17 @@ void rules_setup(void) {
     if (rule_options.event_cb == NULL) { //check if not initialized before
 #ifdef ESP32
       if (mempool == NULL) { //make sure we only malloc if not done before
-        mempool = (unsigned char *)ps_malloc(MEMPOOL_SIZE);  //in arduino IDE normal malloc causes big block to go to PSRAM if PSRAM is enabled. But seems to be unstable so for now don't enable PSRAM
+        mempool = (unsigned char *)ps_malloc(MEMPOOL_SIZE);
         if (mempool == NULL) {
-          logprintln_P(F("Mempool OOM"));
-          OUT_OF_MEMORY
+          logprintln_P(F("Mempool OOM, rules disabled"));
+          return;
         }
       }
-#endif  
+#endif
+    if (mempool == NULL) {
+      logprintln_P(F("Mempool unavailable, rules disabled"));
+      return;
+    }
     memset(mempool, 0, MEMPOOL_SIZE);
 
     logprintf_P(F("rules mempool size: %d"), MEMPOOL_SIZE);
@@ -940,7 +944,11 @@ bool existsRulesFile(char *file) {
 int rules_parse(char *file) {
   if (existsRulesFile(file)) { //only parse an existing and not empty, file
     rules_setup(); //check there if done already
-	
+    if (mempool == NULL) {
+      logprintln_P(F("Rules parser unavailable: mempool not initialized"));
+      return -1;
+    }
+
     File frules = LittleFS.open(file, "r");
     parsing = 1;
 

--- a/HeishaMon/src/common/mem.cpp
+++ b/HeishaMon/src/common/mem.cpp
@@ -7,9 +7,5 @@
 */
 
 unsigned int alignedbuffer(int v) {
-#if defined(ESP8266)
   return (v + 3) & ~0x3;
-#else
-  return v;
-#endif
 }


### PR DESCRIPTION
rules_setup() logged "Mempool OOM" on ps_malloc() failure but then fell through OUT_OF_MEMORY (a no-op) into memset(mempool, ...) on a NULL pointer. Return early instead, and guard rules_parse() the same way since it also dereferences mempool after calling rules_setup().

Also make alignedbuffer() round up to a 4-byte boundary on ESP32 as it already does on ESP8266, instead of returning the offset unaligned. The rules VM casts mempool offsets to structs declared aligned(4); unaligned access to a heap pointer the compiler doesn't know is PSRAM-backed isn't covered by ESP32's unaligned-access exception handler the way internal RAM access is, so this keeps offsets safely aligned regardless of where mempool is allocated.

PSRAM allocation (ps_malloc) for the mempool is left as-is.