### PR TITLE
docs: document SetReset command (SET48) for clearing fault codes

### DIFF
--- a/MQTT-Topics.md
+++ b/MQTT-Topics.md
@@ -236,6 +236,7 @@ SET44 | SetDHWHeaterState | Allow DHW backup/booster heater | 0=blocked, 1=free
 SET45 | SetRoomHeaterState | Allow Room backup/booster heater | 0=blocked, 1=free
 SET46 | SetHeaterOnOutdoorTemp | Outdoor temperature for heater ON | -15 to 20
 SET47 | SetForceHeater | Force heater mode (emergency heating), same as the heater button on the remote. State is reported in TOP68 | 0=off, 1=on
+SET48 | SetReset | Reset/confirm active heatpump fault code (e.g. H72). Equivalent to pressing "Reset" on the CZ-TAW1 remote / indoor unit panel. Writes byte 8 of the outgoing query. Clears latched errors that soft power-cycle (`SetHeatpump` 0→1) cannot clear. | 0=no action, 1=reset
 
 
 *If you operate your heatpump in water mode with direct temperature setup: topics ending xxxRequestTemperature will set the absolute target temperature.*


### PR DESCRIPTION
﻿Closes #943.

## What

Documents the previously undocumented SetReset command as **SET48** in MQTT-Topics.md.

The command is implemented in `commands.cpp` (`set_reset()`) and writes the requested value into **byte 8** of the outgoing `panasonicSendQuery`, which the heat pump interprets as a fault-code reset / confirm — equivalent to pressing the physical "Reset" button on the CZ-TAW1 remote or the indoor unit panel.

## Why

A latched fault code (e.g. **H72** — DHW temperature sensor) cannot be cleared programmatically via soft power-cycle (`SetHeatpump` 0→1) or even a hard mains power-cycle in some cases. The only documented workaround was a manual reset at the panel, which is not viable for remote/automated setups.

`SetReset=1` clears these latched errors within ~15 seconds.

### Verified scenario (H72)
| | Before `SetReset=1` | After `SetReset=1` |
|---|---|---|
| `DHW_Temp` (TOP10) | `-128` (sensor read failure → `0x00` decoded via `getIntMinus128`) | `32` (sensor alive) |
| `Error` (TOP44) | `H72` | `No error` |
| `Heatpump_State` | `off` (lockout, ignores `SetHeatpump=1`) | accepts commands again |

Hexdump logging (`togglehexdump` + `toggleMqtt`) confirmed the 203-byte query frames continued normally throughout (checksum OK), so serial comms were fine — only the reset bit needed to be sent.

## Environment
- HeishaMon Large (ESP32-S3), firmware v4.1.8
- Panasonic Aquarea

Follows the same style as the recently merged SET47 (`SetForceHeater`, #936).
