### PR TITLE
Fix rules engine crash on call statement followed by sibling if with …

### DIFF
--- a/HeishaMon/src/rules/rules.cpp
+++ b/HeishaMon/src/rules/rules.cpp
@@ -3361,6 +3361,14 @@ static int16_t rule_create(char **text, struct rules_t *obj) {
               case TEVENT:
               case TFUNCTION:
               case LPAREN: {
+                /*
+                 * A call/expression statement is followed by a sibling
+                 * statement (nested if, event, or function call) rather
+                 * than closing the block. Reset mathcnt here too, for the
+                 * same reason as the TEND case below (#894): otherwise it
+                 * leaks into the next statement's slot allocation.
+                 */
+                mathcnt = 0;
                 go = type;
                 ret = TIF;
                 continue;


### PR DESCRIPTION
…&& condition

Extends the #894 mathcnt-reset fix (bf9fcda/913e8eb), which only reset the temporary slot counter when a call statement closed an if-block via `end`. The same slot leak happens when a call statement is instead followed by a sibling statement (nested if, event, or function call) at the same level - bc_parse_math_order's backward slot search can still overshoot into the call's slots and corrupt the next statement's condition, notably a following && compound condition.

Reported in #946: user rules with `setTimer(...); if $a >= x && $a < y then ... end` inside a nested if-block failed to run despite validating cleanly, because the corrupted bytecode aborted at runtime with a FATAL internal error.

Fix and a regression test were verified upstream in https://github.com/IgorYbema/rules (branch fix-894-mathcnt-reset, commits 0df59aa and 7898b10) against the full 527-case test suite.