### PR TITLE
Fix broken image links in ioBroker_manual README (#907)

### DIFF
--- a/Integrations/ioBroker_manual/README.md
+++ b/Integrations/ioBroker_manual/README.md
@@ -8,14 +8,14 @@ With this manual, you can manually integrate the heishamon into iobroker via mqt
 
 ## Installation
 1. Install the mqtt adapter for iobroker. Go to *Adapters* and search for `mqtt`.  
-![adapters_mqtt](https://github.com/emign/HeishaMon/blob/master/Integrations/ioBroker_manual/images/adapters_mqtt.png)
+![adapters_mqtt](images/adapters_mqtt.png)
 2. Install the `MQTT Broker/Client` adapter with clicking the plus-symbol in the correspinding line. Wait for it to finish.
 
 ## Configuration
 
 1. Navigate to the iobroker `Instances` menu and click on the wrench symbol for the mqtt-instance. It will most likely be called `mqtt.0`
 
-![mqtt_setup](https://github.com/emign/HeishaMon/blob/master/Integrations/ioBroker_manual/images/mqtt_setup.png)
+![mqtt_setup](images/mqtt_setup.png)
 
 2. Configure the Connection settings as follows:
 
@@ -39,11 +39,11 @@ Password: Password you want your mqtt clients to authenticate with
 2. Navigate to `objects`
 3. Wait. (seriously: wait, grab a coffee or something. iobroker sometimes needs minutes to detect all incoming messages and propagate them correctly)
 
-![iobroker_objects](https://github.com/emign/HeishaMon/blob/master/Integrations/ioBroker_manual/images/iobroker_objects.png)
+![iobroker_objects](images/iobroker_objects.png)
 
 4. When everything is setup correctly, a new group `panasonic_heat_pump` will be displayed. Under the subgroup `sdc` there already should be values coming in. They flash green when updated
 
-![sdc values](https://github.com/emign/HeishaMon/blob/master/Integrations/ioBroker_manual/images/sdc_values.png)
+![sdc values](images/sdc_values.png)
 
 # Setting values
 


### PR DESCRIPTION
The README linked to images on a stale fork (emign/HeishaMon, master branch) that no longer exists, returning 404s. Switch to relative paths so the images that already live in this repo's images/ folder resolve correctly.