### PR TITLE
Point AGENTS.md's SKILL.md instruction at its actual location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This file provides guidance when working with code in this repository. Always read the SKILL.md files in this repository first!
+This file provides guidance when working with code in this repository. Before writing or editing any rules-engine file (`rules.txt`, `src/rules/`), read the `heishamon-rules` skill at `Examples/Rules/SKILL.md` first.
 
 ## What this is
 


### PR DESCRIPTION
## Summary
- AGENTS.md's opening line said "Always read the SKILL.md files in this repository first!" without saying where they are, forcing an agent to search the repo.
- Points it directly at `Examples/Rules/SKILL.md` and scopes it to rules-engine work, matching the more precise instruction already given later in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)