### PR TITLE
Add KIT-AQC9HE8 heat pump type

### DIFF
--- a/HeatPumpType.md
+++ b/HeatPumpType.md
@@ -78,6 +78,7 @@ Assuming that bytes from #129 to #138 are unique for each model of Aquarea heat 
 |71 | E2 D5 0B 35 99 83 92 0D 29 98 | WH-SDC0509L6E5 | WH-WDG09LE5 | KIT-WC09L6E5 | 9 | 1 ph | HP - split L-series 6kW elec heating |
 |72 | 12 D7 0B 98 14 35 94 0D 83 10 | WH-SDC0316M9E8 | WH-WXG09ME8 | Monoblock | 9 | 3ph | T-CAP - M-series  |
 |73 | E2 CF 0C 77 09 12 D0 0B 05 11 | WH-SXC09H3E5 | WH-UX09HE5 | KIT-WXC09H3E5 | 9 | 1ph | T-CAP |
+|74 | E2 CF 0C 74 09 12 D0 0B 91 05 | WH-ADC0916H9E8 | WH-UQ09HE8 | KIT-AQC9HE8 | 9 | 3ph | T-CAP - All-In-One |
 
 All bytes are used for Heat Pump model identification in the code.
 


### PR DESCRIPTION
Add verified Panasonic Aquarea T-CAP KIT-AQC9HE8 heat pump model.

Verified hardware:
- IDU: WH-ADC0916H9E8
- ODU: WH-UQ09HE8
- KIT: KIT-AQC9HE8
- Power: 9 kW
- Phase: 3ph
- Type: T-CAP All-In-One
- Bytes 129-138: E2 CF 0C 74 09 12 D0 0B 91 05

The model information was verified from the installation documentation and the byte signature was captured directly from HeishaMon.