### PR TITLE
Add WH-WXG12ME8 M-series model

### DIFF
--- a/HeatPumpType.md
+++ b/HeatPumpType.md
@@ -79,6 +79,7 @@ Assuming that bytes from #129 to #138 are unique for each model of Aquarea heat 
 |72 | 12 D7 0B 98 14 35 94 0D 83 10 | WH-SDC0316M9E8 | WH-WXG09ME8 | Monoblock | 9 | 3ph | T-CAP - M-series  |
 |73 | E2 CF 0C 77 09 12 D0 0B 05 11 | WH-SXC09H3E5 | WH-UX09HE5 | KIT-WXC09H3E5 | 9 | 1ph | T-CAP |
 |74 | C2 D3 0D 33 65 B2 D3 0B 94 65 | Monoblock | WH-MDC05J3E5 | Monoblock | 5 | 1ph | HP - J Series |
+|75 | 12 D7 0D 98 11 39 94 0F 84 10 | WH-ADC0316M9E8AN2 | WH-WXG12ME8 | Monoblock | 12 | 3ph | T-CAP - M-series DHW 185l |
 
 All bytes are used for Heat Pump model identification in the code.
 


### PR DESCRIPTION
## Summary

- Add the user-verified TOP92 signature for the Panasonic
  WH-ADC0316M9E8AN2 + WH-WXG12ME8 combination.
- Document it as a 12 kW, three-phase T-CAP M-series All-in-One
  system with a 185 L DHW tank.

## Evidence

- Captured the following raw TOP92 value from
  `main/Heat_Pump_Model` on a live system running HeishaMon v4.2.1:

  `12 D7 0D 98 11 39 94 0F 84 10`

- Confirmed the installed unit labels as:
  - IDU: `WH-ADC0316M9E8AN2`
  - ODU: `WH-WXG12ME8`
- Panasonic documentation confirms this pairing as a 12 kW,
  three-phase T-CAP M-series All-in-One system with a 185 L DHW tank.

## Comparison with the existing 9 kW model

The existing 9 kW combination uses the same indoor unit with
`WH-WXG09ME8` and has this signature:

`12 D7 0D 98 11 33 94 0C 83 10`

The new 12 kW signature differs at telegram bytes 134, 136, and 137,
so it is a distinct model signature.

## Validation

- Signature contains exactly ten bytes.
- Signature is unique in the table.
- Model-table numbering remains sequential.
- `git diff --check` passes.